### PR TITLE
seo: fix double title, font-display swap, preconnect, cache headers, …

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -14,16 +14,20 @@ import { TwoStepModal } from '@/components/two-step-modal';
 import { GlobalPopupWrapper } from '@/components/global-popup-wrapper';
 import { CustomToaster } from '@/components/custom-toaster';
 
-const GA_MEASUREMENT_ID = 'G-30XJX7BT9D'; // substituir pelo Measurement ID real do GA4
+const GA_MEASUREMENT_ID = 'G-30XJX7BT9D';
 
+// display: 'swap' elimina o FOIT (flash de texto invisível) durante o
+// carregamento da fonte, melhorando o FCP e reduzindo o CLS de fontes.
 const geistSans = Geist({
   variable: '--font-geist-sans',
   subsets: ['latin'],
+  display: 'swap',
 });
 
 const geistMono = Geist_Mono({
   variable: '--font-geist-mono',
   subsets: ['latin'],
+  display: 'swap',
 });
 
 export const metadata: Metadata = {
@@ -85,6 +89,32 @@ export default function RootLayout({
     <ClerkProvider>
       <html lang="pt" className={geistSans.className} suppressHydrationWarning>
         <head>
+          {/* ── Preconnect para domínios críticos de terceiros ──────────────
+              Instrui o browser a abrir a ligação TCP/TLS antes de precisar
+              dos recursos, reduzindo a latência percebida (Network Dependency
+              Tree). Impacto direto no TTFB e no LCP em redes móveis. */}
+          <link rel="preconnect" href="https://www.googletagmanager.com" />
+          <link rel="dns-prefetch" href="https://www.googletagmanager.com" />
+          <link rel="preconnect" href="https://www.google-analytics.com" />
+          <link rel="dns-prefetch" href="https://www.google-analytics.com" />
+          <link rel="preconnect" href="https://vacjsnuttfzgcdaaqjxd.supabase.co" />
+          <link rel="dns-prefetch" href="https://vacjsnuttfzgcdaaqjxd.supabase.co" />
+          <link rel="preconnect" href="https://images.ctfassets.net" />
+          <link rel="dns-prefetch" href="https://images.ctfassets.net" />
+
+          {/* ── Preload da imagem LCP do hero ──────────────────────────────
+              Diz ao browser para buscar a imagem principal do hero com
+              alta prioridade antes de processar o HTML completo. Melhora
+              o LCP Request Discovery nas páginas com carrossel de imagens.
+              Substitui o src pelo caminho real da imagem principal do hero. */}
+          <link
+            rel="preload"
+            as="image"
+            href="/onesugar-mobile.jpeg"
+            fetchPriority="high"
+          />
+
+          {/* ── Schema.org Organization ────────────────────────────────── */}
           <script
             type="application/ld+json"
             dangerouslySetInnerHTML={{
@@ -118,7 +148,7 @@ export default function RootLayout({
           />
         </head>
         <body className="min-h-screen flex flex-col">
-          {/* Google Analytics 4 */}
+          {/* ── Google Analytics 4 ──────────────────────────────────────── */}
           <Script
             src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
             strategy="afterInteractive"

--- a/app/location/[city]/page.tsx
+++ b/app/location/[city]/page.tsx
@@ -14,94 +14,98 @@ import { countCompanionsPages } from '@/db/queries/companions';
 import { HeroCarouselWrapper } from '@/components/hero-carousel-wrapper';
 import { PlanType } from '@/db/queries/kv';
 
+// Nota: os títulos aqui NÃO devem terminar com "| Onesugar".
+// O template definido em layout.tsx ( '%s | Onesugar' ) já adiciona o sufixo.
+// Adicionar aqui causaria "Acompanhantes em Lisboa | Onesugar | Onesugar".
+
 const cityMetadata: Record<string, { title: string; description: string; h1: string }> = {
   lisboa: {
-    title: 'Acompanhantes em Lisboa | Perfis Verificados | Onesugar',
+    title: 'Acompanhantes em Lisboa | Perfis Verificados',
     description: 'Encontre as melhores acompanhantes em Lisboa. Perfis verificados, total discrição e segurança na Onesugar. Descubra acompanhantes premium em Lisboa.',
     h1: 'Acompanhantes em Lisboa',
   },
   porto: {
-    title: 'Acompanhantes no Porto | Perfis Verificados | Onesugar',
+    title: 'Acompanhantes no Porto | Perfis Verificados',
     description: 'Procura acompanhantes no Porto? Descubra perfis verificados para encontros privados e seguros através da Onesugar.',
     h1: 'Acompanhantes no Porto',
   },
   braga: {
-    title: 'Acompanhantes em Braga | Perfis Verificados | Onesugar',
+    title: 'Acompanhantes em Braga | Perfis Verificados',
     description: 'Navegue pelos perfis de acompanhantes verificadas em Braga. Descubra companheiras e desfrute de encontros privados com perfis de confiança.',
     h1: 'Acompanhantes em Braga',
   },
   coimbra: {
-    title: 'Acompanhantes em Coimbra | Perfis Verificados | Onesugar',
+    title: 'Acompanhantes em Coimbra | Perfis Verificados',
     description: 'Encontre acompanhantes em Coimbra. Explore perfis premium e marque encontros discretos hoje mesmo na Onesugar.',
     h1: 'Acompanhantes em Coimbra',
   },
   faro: {
-    title: 'Acompanhantes em Faro | Perfis Verificados no Algarve | Onesugar',
+    title: 'Acompanhantes em Faro | Perfis Verificados no Algarve',
     description: 'Descubra acompanhantes em Faro e na região do Algarve. Navegue por perfis verificados para experiências discretas e inesquecíveis.',
     h1: 'Acompanhantes em Faro',
   },
   aveiro: {
-    title: 'Acompanhantes em Aveiro | Perfis Verificados | Onesugar',
+    title: 'Acompanhantes em Aveiro | Perfis Verificados',
     description: 'Encontre acompanhantes em Aveiro. Navegue por perfis verificados e agende encontros privados com acompanhantes de alto nível na Onesugar.',
     h1: 'Acompanhantes em Aveiro',
   },
   viseu: {
-    title: 'Acompanhantes em Viseu | Perfis Verificados | Onesugar',
+    title: 'Acompanhantes em Viseu | Perfis Verificados',
     description: 'Encontre acompanhantes em Viseu. Navegue pelos perfis verificados para experiências discretas e privadas na Onesugar.',
     h1: 'Acompanhantes em Viseu',
   },
   leiria: {
-    title: 'Acompanhantes em Leiria | Perfis Verificados | Onesugar',
+    title: 'Acompanhantes em Leiria | Perfis Verificados',
     description: 'Procura acompanhantes em Leiria? Explore perfis verificados e desfrute de experiências privadas com acompanhantes de confiança na Onesugar.',
     h1: 'Acompanhantes em Leiria',
   },
   setubal: {
-    title: 'Acompanhantes em Setúbal | Perfis Verificados | Onesugar',
+    title: 'Acompanhantes em Setúbal | Perfis Verificados',
     description: 'Explore o catálogo de acompanhantes em Setúbal. Descubra companheiras e desfrute de encontros seguros e discretos na Onesugar.',
     h1: 'Acompanhantes em Setúbal',
   },
   evora: {
-    title: 'Acompanhantes em Évora | Perfis Verificados | Onesugar',
+    title: 'Acompanhantes em Évora | Perfis Verificados',
     description: 'Procura acompanhantes em Évora? Descubra perfis verificados que oferecem experiências privadas e inesquecíveis na Onesugar.',
     h1: 'Acompanhantes em Évora',
   },
   guarda: {
-    title: 'Acompanhantes na Guarda | Perfis Verificados | Onesugar',
+    title: 'Acompanhantes na Guarda | Perfis Verificados',
     description: 'Descubra acompanhantes na Guarda. Encontre perfis de confiança e desfrute de encontros discretos na Onesugar.',
     h1: 'Acompanhantes na Guarda',
   },
   braganca: {
-    title: 'Acompanhantes em Bragança | Perfis Verificados | Onesugar',
+    title: 'Acompanhantes em Bragança | Perfis Verificados',
     description: 'Descubra acompanhantes em Bragança. Navegue pelos perfis verificados e desfrute de encontros privados e discretos na Onesugar.',
     h1: 'Acompanhantes em Bragança',
   },
   'castelo-branco': {
-    title: 'Acompanhantes em Castelo Branco | Perfis Verificados | Onesugar',
+    title: 'Acompanhantes em Castelo Branco | Perfis Verificados',
     description: 'Encontre acompanhantes em Castelo Branco. Navegue por perfis verificados e combine encontros seguros e privados na Onesugar.',
     h1: 'Acompanhantes em Castelo Branco',
   },
   santarem: {
-    title: 'Acompanhantes em Santarém | Perfis Verificados | Onesugar',
+    title: 'Acompanhantes em Santarém | Perfis Verificados',
     description: 'Descubra acompanhantes em Santarém. Navegue por perfis verificados e agende encontros privados com facilidade na Onesugar.',
     h1: 'Acompanhantes em Santarém',
   },
   'vila-real': {
-    title: 'Acompanhantes em Vila Real | Perfis Verificados | Onesugar',
+    title: 'Acompanhantes em Vila Real | Perfis Verificados',
     description: 'Procura acompanhantes em Vila Real? Explore perfis verificados e desfrute de encontros privados e seguros na Onesugar.',
     h1: 'Acompanhantes em Vila Real',
   },
   'viana-do-castelo': {
-    title: 'Acompanhantes em Viana do Castelo | Perfis Verificados | Onesugar',
+    title: 'Acompanhantes em Viana do Castelo | Perfis Verificados',
     description: 'Descubra acompanhantes em Viana do Castelo. Navegue pelos perfis verificados e desfrute de experiências privadas na Onesugar.',
     h1: 'Acompanhantes em Viana do Castelo',
   },
   portalegre: {
-    title: 'Acompanhantes em Portalegre | Perfis Verificados | Onesugar',
+    title: 'Acompanhantes em Portalegre | Perfis Verificados',
     description: 'Encontre acompanhantes em Portalegre. Perfis verificados, total discrição e segurança na Onesugar.',
     h1: 'Acompanhantes em Portalegre',
   },
   beja: {
-    title: 'Acompanhantes em Beja | Perfis Verificados | Onesugar',
+    title: 'Acompanhantes em Beja | Perfis Verificados',
     description: 'Encontre acompanhantes em Beja. Perfis verificados, total discrição e segurança na Onesugar.',
     h1: 'Acompanhantes em Beja',
   },
@@ -118,7 +122,7 @@ export async function generateMetadata({
     city.charAt(0).toUpperCase() + city.slice(1).replaceAll('-', ' ');
 
   const current = cityMetadata[cityKey] || {
-    title: `Acompanhantes em ${capitalizedCity} | Onesugar`,
+    title: `Acompanhantes em ${capitalizedCity} | Perfis Verificados`,
     description: `Encontre as melhores acompanhantes em ${capitalizedCity}. Perfis verificados, total discrição e segurança na Onesugar.`,
     h1: `Acompanhantes em ${capitalizedCity}`,
   };
@@ -208,4 +212,3 @@ export default async function CompanionsPage({
     </div>
   );
 }
-

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,6 +3,7 @@ import type { NextConfig } from 'next';
 const nextConfig: NextConfig = {
   trailingSlash: false,
 
+  // ── Redirects ────────────────────────────────────────────────────────────
   async redirects() {
     return [
       {
@@ -18,13 +19,70 @@ const nextConfig: NextConfig = {
     ];
   },
 
+  // ── Cache headers ────────────────────────────────────────────────────────
+  // Assets estáticos do Next.js usam hashes no nome do ficheiro, por isso
+  // é seguro aplicar cache longo (immutable). O Google PageSpeed penaliza
+  // ausência de cache policy — este bloco elimina esse aviso.
+  async headers() {
+    return [
+      {
+        // Chunks JS e CSS com hash gerados pelo Next.js build
+        source: '/_next/static/:path*',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=31536000, immutable',
+          },
+        ],
+      },
+      {
+        // Imagens, fontes e ficheiros estáticos em /public
+        source: '/:path*\\.(ico|png|jpg|jpeg|svg|webp|avif|woff|woff2|ttf|otf)',
+        headers: [
+          {
+            key: 'Cache-Control',
+            value: 'public, max-age=86400, stale-while-revalidate=604800',
+          },
+        ],
+      },
+      {
+        // Headers de segurança — resolve 949 issues identificados na auditoria
+        source: '/:path*',
+        headers: [
+          {
+            key: 'X-Content-Type-Options',
+            value: 'nosniff',
+          },
+          {
+            key: 'X-Frame-Options',
+            value: 'SAMEORIGIN',
+          },
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin',
+          },
+          {
+            key: 'Permissions-Policy',
+            value: 'camera=(), microphone=(), geolocation=()',
+          },
+        ],
+      },
+    ];
+  },
+
   experimental: {
     serverActions: {
       bodySizeLimit: '50mb',
     },
   },
 
+  // ── Image optimization ───────────────────────────────────────────────────
+  // Adiciona AVIF e WebP como formatos de saída do Next.js Image.
+  // O browser recebe o formato mais eficiente que suporta.
+  // Reduz o payload das imagens em 25-40% vs JPEG — impacto direto no LCP
+  // e no PageSpeed "Improve Image Delivery".
   images: {
+    formats: ['image/avif', 'image/webp'],
     remotePatterns: [
       {
         protocol: 'https',

--- a/next.config.ts
+++ b/next.config.ts
@@ -20,13 +20,14 @@ const nextConfig: NextConfig = {
   },
 
   // ── Cache headers ────────────────────────────────────────────────────────
-  // Assets estáticos do Next.js usam hashes no nome do ficheiro, por isso
-  // é seguro aplicar cache longo (immutable). O Google PageSpeed penaliza
-  // ausência de cache policy — este bloco elimina esse aviso.
   async headers() {
     return [
       {
-        // Chunks JS e CSS com hash gerados pelo Next.js build
+        // Chunks JS e CSS gerados pelo Next.js build — nomes com hash imutável.
+        // Safe para cache de 1 ano + immutable: o nome do ficheiro muda a cada
+        // build, tornando impossível servir versão antiga ao utilizador.
+        // IMPORTANTE: este bloco não pode ser removido — sem ele o PageSpeed
+        // continua a sinalizar ausência de cache policy nos assets estáticos.
         source: '/_next/static/:path*',
         headers: [
           {
@@ -36,17 +37,22 @@ const nextConfig: NextConfig = {
         ],
       },
       {
-        // Imagens, fontes e ficheiros estáticos em /public
-        source: '/:path*\\.(ico|png|jpg|jpeg|svg|webp|avif|woff|woff2|ttf|otf)',
+        // Imagens, fontes e ficheiros estáticos em /public.
+        // Cache reduzido para 1h conforme solicitado pelo Sandri: perfis de
+        // acompanhantes têm fotos que podem ser actualizadas a qualquer momento,
+        // por isso cache longo causaria utilizadores a ver imagens desactualizadas.
+        // stale-while-revalidate: serve a versão em cache enquanto busca nova em background.
+        source: '/(.*\\.(?:ico|png|jpg|jpeg|svg|webp|avif|woff|woff2|ttf|otf)$)',
         headers: [
           {
             key: 'Cache-Control',
-            value: 'public, max-age=86400, stale-while-revalidate=604800',
+            value: 'public, max-age=3600, stale-while-revalidate=86400',
           },
         ],
       },
       {
-        // Headers de segurança — resolve 949 issues identificados na auditoria
+        // Headers de segurança globais — resolve 949 issues de segurança
+        // identificados na auditoria técnica inicial (1 deploy cobre todas as rotas).
         source: '/:path*',
         headers: [
           {
@@ -77,10 +83,6 @@ const nextConfig: NextConfig = {
   },
 
   // ── Image optimization ───────────────────────────────────────────────────
-  // Adiciona AVIF e WebP como formatos de saída do Next.js Image.
-  // O browser recebe o formato mais eficiente que suporta.
-  // Reduz o payload das imagens em 25-40% vs JPEG — impacto direto no LCP
-  // e no PageSpeed "Improve Image Delivery".
   images: {
     formats: ['image/avif', 'image/webp'],
     remotePatterns: [


### PR DESCRIPTION
Este PR consolida três entregas do roadmap técnico de SEO: fechamento do Mês 1 e avanço em quatro issues do Mês 2 (Performance). Três arquivos foram alterados.



1. app/location/[city]/page.tsx — Correção do título duplicado (Page Titles: Multiple)

Todos os títulos das 18 páginas de distrito estavam a sair com o sufixo "| Onesugar" duplicado, por exemplo: "Acompanhantes em Lisboa | Perfis Verificados | Onesugar | Onesugar". A causa era um conflito entre o template definido no layout.tsx (`'%s | Onesugar'`) e o sufixo que já estava presente em cada título individual no generateMetadata. O template foi criado exactamente para adicionar esse sufixo automaticamente em todas as páginas, por isso o sufixo foi removido de cada entrada individual no cityMetadata. O resultado esperado é que todos os títulos passem a ter exactamente uma ocorrência da marca: "Acompanhantes em Lisboa | Perfis Verificados | Onesugar". Isso elimina ambiguidade para o Google, melhora o CTR nas SERPs e resolve o issue Page Titles: Multiple identificado no audit.


2. app/layout.tsx — Font Display Swap + Preconnect para domínios críticos + Preload da imagem LCP

Três melhorias de performance foram adicionadas neste arquivo:

- `display: 'swap'` nas fontes Geist Sans e Geist Mono: sem esta configuração, o browser bloqueia a renderização do texto enquanto a fonte carrega, causando FOIT (flash de texto invisível) e penalizando o FCP e o CLS nos Core Web Vitals. Com `swap`, o browser usa uma fonte de sistema como fallback imediato e substitui quando a fonte estiver disponível, tornando a página visível mais depressa.

- `<link rel="preconnect">` e `<link rel="dns-prefetch">` para Google Tag Manager, Google Analytics, Supabase e Contentful: estes headers instruem o browser a abrir a ligação TCP/TLS com os domínios de terceiros antes de os recursos serem solicitados. Resolve directamente o issue PageSpeed: Network Dependency Tree, que afectava 67 páginas, reduzindo a latência percebida especialmente em redes móveis em Portugal.

- `<link rel="preload" fetchpriority="high">` para a imagem principal do hero: diz ao browser para buscar a imagem do carrossel com prioridade máxima ainda durante o parsing do HTML, antes de qualquer script ser executado. Ataca o issue PageSpeed: LCP Request Discovery, que afectava 28 páginas, com impacto directo na métrica LCP do GSC.


3. next.config.ts — Cache Headers + Formatos de imagem modernos + Headers de segurança

Três blocos foram adicionados à configuração:

- Cache `immutable` para `/_next/static/`: os assets gerados pelo build do Next.js têm hash no nome do ficheiro, o que torna seguro aplicar cache de longa duração. O Google PageSpeed penaliza ausência de cache policy nesses recursos. Com `max-age=31536000, immutable`, o browser guarda os assets localmente e não os volta a pedir nas visitas seguintes, reduzindo o tempo de carregamento para utilizadores recorrentes.

- `formats: ['image/avif', 'image/webp']` no bloco de images: activa a entrega automática de AVIF e WebP pelo componente Image do Next.js. O browser recebe o formato mais eficiente que suporta, com redução de 25 a 40% no tamanho das imagens face ao JPEG. Resolve o issue PageSpeed: Improve Image Delivery nas 20 páginas afectadas.

- Headers de segurança globais (`X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy`): adicionados em todas as rotas num único deploy, resolvem 949 issues de segurança identificados na auditoria técnica inicial.



Pedido de ação

Antes de fazer o merge, confirmar um ponto no layout.tsx: o preload foi configurado para `/onesugar-mobile.jpeg`, que foi a imagem identificada no crawl do Screaming Frog como sendo carregada na homepage. Se o ficheiro principal do hero tiver um nome diferente na pasta public, actualizar o `href` do preload antes de aceitar o PR para garantir que o hint aponta para o recurso correcto. Após o merge e deploy, validar o título de qualquer location page via View Source para confirmar que o sufixo aparece apenas uma vez.