### PR TITLE
seo: add editorial content for Porto, Lisboa, Braga, Aveiro, Coimbra,…

### DIFF
--- a/app/location/[city]/page.tsx
+++ b/app/location/[city]/page.tsx
@@ -7,14 +7,12 @@ import {
   CompanionsListSkeleton,
 } from '@/components/companionsList';
 import { CompanionFilters } from '@/components/companionFilters';
-import CompanionsLayout from '@/app/companions/layout';
-import { stringify } from 'querystring';
 import Pagination from '@/components/ui/pagination';
 import { countCompanionsPages } from '@/db/queries/companions';
 import { HeroCarouselWrapper } from '@/components/hero-carousel-wrapper';
 import { PlanType } from '@/db/queries/kv';
 
-// ─── Types ────────────────────────────────────────────────────────────────────
+// ── Types ─────────────────────────────────────────────────────────────────────
 
 interface EditorialSection {
   heading?: string;
@@ -44,13 +42,366 @@ interface CityData {
   faq?: CityFAQItem[];
 }
 
-// ─── Content ──────────────────────────────────────────────────────────────────
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/**
+ * Converte um slug em formato kebab-case para um nome de cidade legível,
+ * capitalizando cada palavra. Ex.: "viana-do-castelo" → "Viana Do Castelo".
+ */
+function formatCitySlug(slug: string): string {
+  return slug
+    .split('-')
+    .map((word) =>
+      word.length > 0 ? word.charAt(0).toUpperCase() + word.slice(1) : word,
+    )
+    .join(' ');
+}
+
+// ── Content ───────────────────────────────────────────────────────────────────
 // Nota: os títulos NÃO terminam com "| Onesugar".
 // O template definido em layout.tsx ('%s | Onesugar') adiciona o sufixo.
 
 const cityMetadata: Record<string, CityData> = {
 
   // ── Distritos com conteúdo editorial completo ─────────────────────────────
+
+  porto: {
+    title: 'Acompanhantes no Porto | Perfis Verificados',
+    description:
+      'Encontre acompanhantes verificadas no Porto. Perfis reais, discrição total e a maior selecção de escorts do norte de Portugal na Onesugar.',
+    h1: 'Acompanhantes no Porto',
+    intro:
+      'O Porto é a segunda maior cidade de Portugal e uma das capitais europeias com maior crescimento turístico da última década. Para quem procura acompanhantes no Porto com perfis verificados e encontros discretos, a Onesugar disponibiliza a maior selecção de companheiras activas na cidade e na área metropolitana. Da Ribeira à Boavista, de Matosinhos ao centro histórico, os perfis da plataforma cobrem as principais zonas do Grande Porto com disponibilidade actualizada. Todos os perfis são verificados antes de qualquer publicação. Navegue pela selecção disponível, filtre por preferência e entre em contacto directamente, sem intermediários.',
+    editorial: {
+      mainHeading: 'Acompanhantes no Porto: a maior selecção verificada da cidade',
+      sections: [
+        {
+          paragraphs: [
+            'O Porto concentra o maior volume de procura por acompanhantes do norte de Portugal, reflexo de uma cidade que combina um tecido urbano activo, turismo internacional em crescimento constante e uma vida nocturna que é referência a nível nacional. A procura por escorts no Porto e por acompanhantes de luxo na cidade tem crescido de forma consistente, acompanhando o perfil cada vez mais diversificado de quem visita e vive aqui.',
+            'Na Onesugar, os perfis disponíveis no Porto cobrem diferentes tipos de encontro: companhia para jantares e eventos, encontros privados, e perfis especializados para quem procura experiências específicas. Todos os perfis passaram pelo processo de verificação da plataforma, o que garante que as informações apresentadas são actuais e correspondem à realidade.',
+          ],
+        },
+        {
+          heading: 'Por que verificação importa no Porto',
+          paragraphs: [
+            'A dimensão do mercado portuense atrai também uma quantidade significativa de perfis falsos e anúncios desactualizados noutros portais. Encontrar uma acompanhante no Porto com informação fiável exige, nessa realidade, um nível de triagem que consome tempo e gera frustração. A Onesugar resolve esse problema antes de o utilizador chegar à plataforma: apenas perfis verificados são publicados.',
+            'Para quem procura acompanhantes de luxo no Porto para um jantar na Foz, um evento na Boavista ou um encontro privado no centro histórico, a selecção verificada poupa tempo e elimina o risco.',
+          ],
+        },
+        {
+          heading: 'O Porto e os visitantes internacionais',
+          paragraphs: [
+            'A cidade recebe um número crescente de visitantes britânicos, franceses e americanos, muitos dos quais procuram escorts no Porto com disponibilidade para comunicar em inglês. Os perfis da Onesugar incluem acompanhantes com diferentes competências linguísticas, tornando-os adequados tanto para clientes nacionais como para visitantes internacionais.',
+            'A plataforma não guarda histórico de contactos nem partilha dados pessoais. A discrição é garantida de ambos os lados.',
+          ],
+        },
+      ],
+      nearbyLinks: [
+        { city: 'Braga', slug: 'braga' },
+        { city: 'Aveiro', slug: 'aveiro' },
+        { city: 'Vila Real', slug: 'vila-real' },
+      ],
+    },
+    faq: [
+      {
+        q: 'Como encontrar acompanhantes verificadas no Porto?',
+        a: 'Na Onesugar, navegue pelos perfis disponíveis no Porto e filtre por tipo de encontro, disponibilidade ou preferência. O contacto é feito directamente com a acompanhante, sem intermediários.',
+      },
+      {
+        q: 'Há escorts no Porto disponíveis para visitantes internacionais?',
+        a: 'Sim. A plataforma tem perfis com disponibilidade para comunicar em inglês e outras línguas. Consulte a descrição de cada perfil para confirmar as línguas disponíveis.',
+      },
+      {
+        q: 'A Onesugar tem acompanhantes de luxo no Porto?',
+        a: 'Sim. Os perfis verificados do Porto incluem acompanhantes de luxo com experiência em jantares, eventos sociais e encontros privados de alto padrão.',
+      },
+      {
+        q: 'É seguro contactar acompanhantes no Porto através da Onesugar?',
+        a: 'A verificação de perfis elimina os riscos mais comuns de portais sem moderação. Os dados pessoais dos utilizadores não são partilhados com terceiros e a navegação pode ser feita sem registo.',
+      },
+      {
+        q: 'Há massagens eróticas disponíveis no Porto na plataforma?',
+        a: 'A Onesugar lista diferentes tipos de perfis, incluindo profissionais de massagem sensorial. Consulte a descrição de cada perfil para ver o tipo de serviço disponível.',
+      },
+    ],
+  },
+
+  lisboa: {
+    title: 'Acompanhantes em Lisboa | Perfis Verificados',
+    description:
+      'Encontre acompanhantes verificadas em Lisboa. Perfis reais, escorts de luxo e a maior selecção da capital portuguesa na Onesugar.',
+    h1: 'Acompanhantes em Lisboa',
+    intro:
+      'Lisboa é a capital de Portugal e uma das cidades europeias com maior crescimento de turismo internacional nos últimos anos. Para quem procura acompanhantes em Lisboa com perfis verificados e encontros discretos, a Onesugar disponibiliza a maior selecção de companheiras activas na cidade e na área metropolitana. De Alfama ao Parque das Nações, do Chiado a Cascais, os perfis da plataforma cobrem as principais zonas de Lisboa com disponibilidade actualizada. Todos os perfis são verificados antes de qualquer publicação. Navegue pela selecção disponível, filtre por preferência e entre em contacto directamente, sem intermediários.',
+    editorial: {
+      mainHeading: 'Acompanhantes em Lisboa: perfis verificados na capital',
+      sections: [
+        {
+          paragraphs: [
+            'Lisboa concentra o maior número de perfis activos de toda a plataforma. A diversidade da cidade, com os seus bairros históricos, zonas de negócios, hotéis de luxo e vida nocturna intensa, gera uma procura igualmente diversa: visitantes internacionais em turismo, profissionais em deslocação, e residentes que procuram companhia verificada e discreta.',
+            'Para quem procura escorts em Lisboa ou acompanhantes de luxo na cidade, a Onesugar é a plataforma com o processo de verificação mais rigoroso disponível em Portugal. Fotografia actual, disponibilidade confirmada, e dados que correspondem ao que encontra na prática.',
+          ],
+        },
+        {
+          heading: 'Lisboa e os visitantes internacionais',
+          paragraphs: [
+            'Lisboa recebe anualmente milhões de visitantes estrangeiros, e uma parte expressiva desses visitantes procura companhia durante a estadia. A procura por escorts em Lisboa em inglês, francês e outras línguas é significativa, reflectindo o perfil cosmopolita da cidade.',
+            'Os perfis da Onesugar em Lisboa incluem acompanhantes com disponibilidade para comunicação em diferentes línguas, tornando a plataforma adequada tanto para clientes nacionais como para quem procura lisbon escorts ou escort lisbon services de qualidade.',
+          ],
+        },
+        {
+          heading: 'Acompanhantes de luxo em Lisboa',
+          paragraphs: [
+            'A cidade tem uma concentração de hotéis de cinco estrelas, restaurantes premiados e espaços privados que criam o contexto ideal para encontros de alto padrão. Os perfis de acompanhantes de luxo em Lisboa disponíveis na Onesugar incluem companheiras com experiência em jantares formais, eventos sociais e encontros privados que exigem um nível de postura e discrição correspondente.',
+            'A Onesugar não guarda histórico de contactos entre utilizadores e acompanhantes, nem partilha qualquer dado com terceiros. A navegação pode ser feita sem registo na maioria das funcionalidades.',
+          ],
+        },
+      ],
+      nearbyLinks: [
+        { city: 'Setúbal', slug: 'setubal' },
+        { city: 'Coimbra', slug: 'coimbra' },
+        { city: 'Porto', slug: 'porto' },
+      ],
+    },
+    faq: [
+      {
+        q: 'Como encontrar acompanhantes em Lisboa com perfis verificados?',
+        a: 'Na Onesugar, todos os perfis listados em Lisboa passaram por verificação de identidade e disponibilidade. Filtre por tipo de encontro, zona e disponibilidade directamente na página.',
+      },
+      {
+        q: 'A Onesugar tem escorts em Lisboa que falam inglês?',
+        a: 'Sim. A plataforma tem perfis com disponibilidade para comunicar em inglês e outras línguas. Consulte a descrição de cada perfil para confirmar as línguas disponíveis.',
+      },
+      {
+        q: 'Há acompanhantes de luxo em Lisboa na plataforma?',
+        a: 'Sim. Os perfis verificados de Lisboa incluem acompanhantes de luxo com experiência em jantares, eventos formais e encontros privados de alto padrão.',
+      },
+      {
+        q: 'Qual é a melhor zona de Lisboa para um encontro discreto?',
+        a: 'Chiado, Príncipe Real e Parque das Nações têm boa oferta hoteleira com privacidade elevada. A escolha depende do perfil e das preferências indicadas por cada acompanhante.',
+      },
+      {
+        q: 'É possível encontrar escort trans em Lisboa através da Onesugar?',
+        a: 'Sim. A plataforma tem perfis diversificados em Lisboa, incluindo acompanhantes trans e travestis verificadas. Consulte as opções disponíveis na página de Lisboa.',
+      },
+    ],
+  },
+
+  braga: {
+    title: 'Acompanhantes em Braga | Perfis Verificados',
+    description:
+      'Encontre acompanhantes verificadas em Braga. Perfis reais, discrição total e escorts verificadas na capital do Minho na Onesugar.',
+    h1: 'Acompanhantes em Braga',
+    intro:
+      'Braga é a terceira maior cidade de Portugal e um dos principais centros urbanos do Minho. Conhecida pela sua arquitectura religiosa e pela vibrante comunidade académica da Universidade do Minho, a cidade combina tradição e modernidade de uma forma que poucos centros urbanos portugueses conseguem. Para quem procura acompanhantes em Braga com perfis verificados e encontros discretos, a Onesugar disponibiliza uma selecção activa de companheiras na cidade e na região. Todos os perfis são verificados antes de qualquer publicação. Navegue pelos perfis disponíveis e contacte directamente.',
+    editorial: {
+      mainHeading: 'Acompanhantes em Braga: oferta verificada na capital do Minho',
+      sections: [
+        {
+          paragraphs: [
+            'Braga ocupa o terceiro lugar no ranking das cidades portuguesas com maior volume de procura por acompanhantes, o que reflecte tanto a sua dimensão urbana como o perfil da sua população. Uma cidade universitária activa, com um centro histórico cada vez mais cosmopolita e uma vida nocturna que se estende pelos bairros da Sé e do centro, Braga tem as condições que sustentam uma procura real e constante.',
+            'Na Onesugar, os perfis disponíveis em Braga incluem acompanhantes verificadas com disponibilidade para diferentes tipos de encontro. A verificação de identidade e disponibilidade é feita antes de qualquer perfil ser publicado, garantindo que as informações são reais e actuais.',
+          ],
+        },
+        {
+          heading: 'O que diferencia Braga de outras cidades do norte',
+          paragraphs: [
+            'A dimensão de Braga cria um equilíbrio entre variedade de oferta e discrição natural. A cidade não tem o mesmo nível de anonimato de uma grande metrópole, mas também não tem a exposição de cidades pequenas. Para quem procura acompanhantes de luxo em Braga para um jantar, evento ou encontro privado, os perfis verificados da Onesugar indicam claramente o tipo de companhia disponível e os contactos preferidos.',
+          ],
+        },
+        {
+          heading: 'Diversidade de perfis em Braga',
+          paragraphs: [
+            'A plataforma tem em Braga uma variedade de perfis que inclui acompanhantes femininas, trans verificadas e perfis com diferentes especialidades. Seja qual for a preferência, os filtros da plataforma permitem encontrar rapidamente o perfil mais adequado.',
+            'A Onesugar não guarda histórico de contactos nem partilha dados pessoais. A privacidade é garantida de ambos os lados.',
+          ],
+        },
+      ],
+      nearbyLinks: [
+        { city: 'Porto', slug: 'porto' },
+        { city: 'Viana do Castelo', slug: 'viana-do-castelo' },
+        { city: 'Vila Real', slug: 'vila-real' },
+      ],
+    },
+    faq: [
+      {
+        q: 'Como encontrar acompanhantes verificadas em Braga?',
+        a: 'Navegue pelos perfis disponíveis em Braga na Onesugar e filtre por preferência ou disponibilidade. O contacto é feito directamente com a acompanhante, sem intermediários.',
+      },
+      {
+        q: 'A Onesugar tem acompanhantes de luxo em Braga?',
+        a: 'Sim. Os perfis verificados de Braga incluem acompanhantes de luxo com experiência em encontros sociais, jantares e momentos privados. A descrição de cada perfil especifica o tipo de companhia disponível.',
+      },
+      {
+        q: 'Há escorts trans disponíveis em Braga na plataforma?',
+        a: 'Sim. A Onesugar tem perfis diversificados em Braga, incluindo acompanhantes trans verificadas. Utilize os filtros disponíveis para encontrar o perfil mais adequado.',
+      },
+      {
+        q: 'É seguro contactar acompanhantes em Braga através da Onesugar?',
+        a: 'A verificação de perfis elimina os riscos mais comuns de portais sem moderação. Os dados pessoais dos utilizadores não são partilhados com terceiros.',
+      },
+    ],
+  },
+
+  aveiro: {
+    title: 'Acompanhantes em Aveiro | Perfis Verificados',
+    description:
+      'Encontre acompanhantes verificadas em Aveiro. Perfis reais, discrição total e escorts de luxo na Veneza de Portugal na Onesugar.',
+    h1: 'Acompanhantes em Aveiro',
+    intro:
+      'Aveiro é uma das cidades mais singulares de Portugal, conhecida pelos seus canais, pelos barcos moliceiros e pela arquitectura Arte Nova que pontua o seu centro histórico. Para quem procura acompanhantes em Aveiro com perfis verificados, a Onesugar disponibiliza uma selecção activa de companheiras na cidade e na região. Com praias a poucos quilómetros, boa ligação ferroviária ao Porto e a Coimbra, e uma presença universitária activa, Aveiro tem as condições para uma oferta diversificada. Todos os perfis são verificados. Navegue abaixo e contacte directamente.',
+    editorial: {
+      mainHeading: 'Acompanhantes em Aveiro: perfis verificados na Veneza de Portugal',
+      sections: [
+        {
+          paragraphs: [
+            'Aveiro é frequentemente descrita como a Veneza portuguesa, uma designação que reflecte tanto a beleza dos seus canais como o carácter único que a distingue de qualquer outra cidade do país. Para quem procura acompanhantes em Aveiro ou escorts na região, essa singularidade é também um atributo: a cidade tem uma escala que combina qualidade de oferta com discrição natural.',
+            'Na Onesugar, os perfis disponíveis em Aveiro passam por verificação antes de qualquer publicação. A verificação de identidade e disponibilidade é o que garante que o utilizador não perde tempo com perfis falsos ou desactualizados.',
+          ],
+        },
+        {
+          heading: 'Aveiro e a região: o que encontra na plataforma',
+          paragraphs: [
+            'Os perfis de Aveiro na Onesugar incluem acompanhantes verificadas para diferentes tipos de encontro, desde companhia social até encontros mais privados. A plataforma tem também perfis de acompanhantes de luxo em Aveiro para quem procura um padrão mais elevado de companhia e discrição.',
+            'A proximidade com a costa, Costa Nova e Mira ficam a menos de 20 minutos, e com cidades como Porto e Coimbra torna Aveiro uma base conveniente para quem se desloca pela região Centro. A Onesugar não guarda histórico de contactos entre utilizadores e acompanhantes, nem partilha dados pessoais com terceiros.',
+          ],
+        },
+      ],
+      nearbyLinks: [
+        { city: 'Porto', slug: 'porto' },
+        { city: 'Coimbra', slug: 'coimbra' },
+        { city: 'Viseu', slug: 'viseu' },
+      ],
+    },
+    faq: [
+      {
+        q: 'Como encontrar acompanhantes em Aveiro com perfis verificados?',
+        a: 'Na Onesugar, todos os perfis listados em Aveiro passaram por verificação. Filtre por disponibilidade ou preferência directamente na página e contacte sem intermediários.',
+      },
+      {
+        q: 'Há acompanhantes de luxo em Aveiro na plataforma?',
+        a: 'Sim. A Onesugar tem perfis de acompanhantes de luxo em Aveiro verificados e com disponibilidade actualizada. Consulte a descrição de cada perfil para ver o tipo de companhia disponível.',
+      },
+      {
+        q: 'Os perfis de acompanhantes em Aveiro são reais?',
+        a: 'Sim. Todos os perfis da Onesugar passam por verificação de identidade e disponibilidade antes de serem publicados. Perfis com o selo verificado confirmaram os dados na plataforma.',
+      },
+      {
+        q: 'É seguro contactar escorts em Aveiro através da Onesugar?',
+        a: 'A verificação de perfis elimina os principais riscos de portais sem moderação. Os dados dos utilizadores não são partilhados com terceiros e a navegação pode ser feita sem registo.',
+      },
+    ],
+  },
+
+  coimbra: {
+    title: 'Acompanhantes em Coimbra | Perfis Verificados',
+    description:
+      'Encontre acompanhantes verificadas em Coimbra. Perfis reais, acompanhantes de luxo e escorts verificadas na cidade universitária na Onesugar.',
+    h1: 'Acompanhantes em Coimbra',
+    intro:
+      'Coimbra é uma das cidades mais emblemáticas de Portugal, sede da mais antiga universidade do país e palco de uma vida académica que molda a sua identidade há séculos. Para quem procura acompanhantes em Coimbra com perfis verificados e encontros discretos, a Onesugar disponibiliza uma selecção activa de companheiras na cidade e na região. O ambiente singular de Coimbra, com os seus bairros históricos, a Alta Universitária e a zona da Baixa, proporciona um contexto com carácter para qualquer tipo de encontro. Todos os perfis são verificados. Navegue abaixo e contacte directamente.',
+    editorial: {
+      mainHeading: 'Acompanhantes em Coimbra: perfis verificados na cidade do conhecimento',
+      sections: [
+        {
+          paragraphs: [
+            'Coimbra tem uma identidade que não se encontra em nenhuma outra cidade portuguesa. A Universidade de Coimbra, Património Mundial da UNESCO, o Fado de Coimbra, as suas repúblicas académicas e o ritmo particular da cidade criam um ambiente com personalidade própria. Para quem procura acompanhantes em Coimbra ou acompanhantes de luxo na cidade, esse contexto é parte do que torna os encontros aqui distintos.',
+            'Na Onesugar, os perfis disponíveis em Coimbra foram verificados individualmente antes de serem publicados. Isso significa fotografias actuais, disponibilidade confirmada e dados que correspondem ao que encontra na prática.',
+          ],
+        },
+        {
+          heading: 'A oportunidade de luxo em Coimbra',
+          paragraphs: [
+            'Coimbra é frequentemente subestimada como destino para acompanhantes de luxo, mas a realidade do mercado conta uma história diferente. A procura por acompanhantes de luxo em Coimbra é significativa e a concorrência na plataforma é menor do que em Lisboa ou Porto, o que resulta numa relação qualidade-preço mais favorável para quem procura este tipo de perfil.',
+            'Para um jantar no centro histórico, um evento na Universidade ou um encontro privado com uma acompanhante verificada de alto padrão, Coimbra oferece opções reais que muitas vezes surpreendem pela qualidade.',
+          ],
+        },
+        {
+          heading: 'Coimbra e a região Centro',
+          paragraphs: [
+            'A posição central de Coimbra no país torna-a também um ponto de passagem frequente entre o norte e o sul. Para quem viaja e procura acompanhantes em Coimbra durante uma estadia, a plataforma tem perfis com disponibilidade tanto durante a semana como ao fim de semana.',
+            'A Onesugar não guarda registos de contacto nem partilha dados pessoais com terceiros.',
+          ],
+        },
+      ],
+      nearbyLinks: [
+        { city: 'Aveiro', slug: 'aveiro' },
+        { city: 'Leiria', slug: 'leiria' },
+        { city: 'Viseu', slug: 'viseu' },
+      ],
+    },
+    faq: [
+      {
+        q: 'Como encontrar acompanhantes em Coimbra com perfis verificados?',
+        a: 'Na Onesugar, todos os perfis listados em Coimbra passaram por verificação de identidade e disponibilidade. Filtre por tipo de encontro, disponibilidade e preferência directamente na página.',
+      },
+      {
+        q: 'Há acompanhantes de luxo em Coimbra disponíveis?',
+        a: 'Sim, e com menos concorrência do que em Lisboa ou Porto. A Onesugar tem perfis de acompanhantes de luxo em Coimbra verificados e com disponibilidade actualizada.',
+      },
+      {
+        q: 'Os perfis de acompanhantes em Coimbra são reais?',
+        a: 'Sim. Todos os perfis da Onesugar passam por verificação de identidade e disponibilidade antes de serem publicados. O selo verificado confirma que os dados foram validados.',
+      },
+      {
+        q: 'Há escorts disponíveis em Coimbra durante a semana?',
+        a: 'Sim. A disponibilidade varia por perfil. Muitos perfis têm disponibilidade durante a semana, especialmente para encontros durante o dia ou à tarde.',
+      },
+      {
+        q: 'A Onesugar tem perfis trans em Coimbra?',
+        a: 'Sim. A plataforma tem perfis diversificados em Coimbra, incluindo acompanhantes trans verificadas. Utilize os filtros disponíveis para encontrar o perfil mais adequado.',
+      },
+    ],
+  },
+
+  'viana-do-castelo': {
+    title: 'Acompanhantes em Viana do Castelo | Perfis Verificados',
+    description:
+      'Encontre acompanhantes verificadas em Viana do Castelo. Perfis reais, discrição total e escorts verificadas no Alto Minho na Onesugar.',
+    h1: 'Acompanhantes em Viana do Castelo',
+    intro:
+      'Viana do Castelo é a capital do Alto Minho, uma cidade com uma identidade cultural forte, marcada pela arquitectura minhota, pela romaria da Senhora da Agonia e pela presença do rio Lima a atravessar o seu centro histórico. Para quem procura acompanhantes em Viana do Castelo com perfis verificados e encontros discretos, a Onesugar disponibiliza companheiras activas na cidade e na região. A menor escala urbana de Viana do Castelo é, para muitos utilizadores, um atributo em termos de discrição. Todos os perfis são verificados. Navegue abaixo e contacte directamente.',
+    editorial: {
+      mainHeading: 'Acompanhantes em Viana do Castelo: o Alto Minho na Onesugar',
+      sections: [
+        {
+          paragraphs: [
+            'Viana do Castelo tem uma posição geográfica que a torna num ponto relevante para quem se desloca entre o Porto e a Galiza, ou para quem vive e trabalha na região do Alto Minho. A cidade tem uma escala humana que combina qualidade de vida com a vitalidade de um centro urbano activo, e essa dimensão é também um factor na procura por acompanhantes em Viana do Castelo.',
+            'Na Onesugar, os perfis disponíveis em Viana do Castelo foram verificados antes de qualquer publicação. Para quem procura escorts em Viana do Castelo ou acompanhantes de luxo na região do Minho, a verificação garante que as informações apresentadas são reais e actuais.',
+          ],
+        },
+        {
+          heading: 'Viana do Castelo: discrição e contexto',
+          paragraphs: [
+            'A menor densidade urbana de Viana do Castelo em comparação com Braga ou Porto é frequentemente mencionada como um factor positivo em termos de discrição. O anonimato é mais fácil de preservar numa cidade de escala intermédia, e a oferta hoteleira local, incluindo unidades junto ao rio Lima e na zona da praia do Cabedelo, oferece opções adequadas para encontros privados.',
+            'A proximidade com Guimarães e Braga torna Viana do Castelo também um ponto de passagem frequente, com perfis activos que têm disponibilidade para encontros em toda a região. A Onesugar não guarda histórico de contactos nem partilha dados com terceiros.',
+          ],
+        },
+      ],
+      nearbyLinks: [
+        { city: 'Braga', slug: 'braga' },
+        { city: 'Porto', slug: 'porto' },
+      ],
+    },
+    faq: [
+      {
+        q: 'Como encontrar acompanhantes em Viana do Castelo?',
+        a: 'Navegue pelos perfis disponíveis em Viana do Castelo na Onesugar, filtre por preferência ou disponibilidade e contacte directamente. Não são necessários intermediários.',
+      },
+      {
+        q: 'Os perfis de acompanhantes em Viana do Castelo são verificados?',
+        a: 'Sim. Todos os perfis publicados na Onesugar passam por verificação de identidade e disponibilidade. O selo de verificação confirma que os dados foram validados pela plataforma.',
+      },
+      {
+        q: 'Há acompanhantes de luxo disponíveis em Viana do Castelo?',
+        a: 'Sim. A Onesugar tem perfis de acompanhantes de luxo em Viana do Castelo para diferentes tipos de encontro. Consulte a descrição de cada perfil para ver o tipo de companhia disponível.',
+      },
+      {
+        q: 'Viana do Castelo tem hotéis adequados para encontros discretos?',
+        a: 'Sim. A cidade tem unidades hoteleiras no centro histórico, junto ao rio Lima e na zona da praia do Cabedelo, com boa privacidade e menor movimento do que nas grandes cidades.',
+      },
+    ],
+  },
 
   'castelo-branco': {
     title: 'Acompanhantes em Castelo Branco | Perfis Verificados',
@@ -376,43 +727,13 @@ const cityMetadata: Record<string, CityData> = {
     ],
   },
 
-  // ── Distritos existentes (título, descrição e H1 apenas) ─────────────────
+  // ── Distritos com título, descrição e H1 apenas ───────────────────────────
 
-  lisboa: {
-    title: 'Acompanhantes em Lisboa | Perfis Verificados',
-    description:
-      'Encontre as melhores acompanhantes em Lisboa. Perfis verificados, total discrição e segurança na Onesugar.',
-    h1: 'Acompanhantes em Lisboa',
-  },
-  porto: {
-    title: 'Acompanhantes no Porto | Perfis Verificados',
-    description:
-      'Procura acompanhantes no Porto? Descubra perfis verificados para encontros privados e seguros através da Onesugar.',
-    h1: 'Acompanhantes no Porto',
-  },
-  braga: {
-    title: 'Acompanhantes em Braga | Perfis Verificados',
-    description:
-      'Navegue pelos perfis de acompanhantes verificadas em Braga. Descubra companheiras e desfrute de encontros privados com perfis de confiança.',
-    h1: 'Acompanhantes em Braga',
-  },
-  coimbra: {
-    title: 'Acompanhantes em Coimbra | Perfis Verificados',
-    description:
-      'Encontre acompanhantes em Coimbra. Explore perfis premium e marque encontros discretos hoje mesmo na Onesugar.',
-    h1: 'Acompanhantes em Coimbra',
-  },
   faro: {
     title: 'Acompanhantes em Faro | Perfis Verificados no Algarve',
     description:
       'Descubra acompanhantes em Faro e na região do Algarve. Navegue por perfis verificados para experiências discretas e inesquecíveis.',
     h1: 'Acompanhantes em Faro',
-  },
-  aveiro: {
-    title: 'Acompanhantes em Aveiro | Perfis Verificados',
-    description:
-      'Encontre acompanhantes em Aveiro. Navegue por perfis verificados e agende encontros privados com acompanhantes de alto nível na Onesugar.',
-    h1: 'Acompanhantes em Aveiro',
   },
   viseu: {
     title: 'Acompanhantes em Viseu | Perfis Verificados',
@@ -444,15 +765,9 @@ const cityMetadata: Record<string, CityData> = {
       'Descubra acompanhantes em Bragança. Navegue pelos perfis verificados e desfrute de encontros privados e discretos na Onesugar.',
     h1: 'Acompanhantes em Bragança',
   },
-  'viana-do-castelo': {
-    title: 'Acompanhantes em Viana do Castelo | Perfis Verificados',
-    description:
-      'Descubra acompanhantes em Viana do Castelo. Navegue pelos perfis verificados e desfrute de experiências privadas na Onesugar.',
-    h1: 'Acompanhantes em Viana do Castelo',
-  },
 };
 
-// ─── Metadata ─────────────────────────────────────────────────────────────────
+// ── Metadata ──────────────────────────────────────────────────────────────────
 
 export async function generateMetadata({
   params,
@@ -461,8 +776,7 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { city } = await params;
   const cityKey = city.toLowerCase();
-  const capitalizedCity =
-    city.charAt(0).toUpperCase() + city.slice(1).replaceAll('-', ' ');
+  const capitalizedCity = formatCitySlug(cityKey);
 
   const current = cityMetadata[cityKey] ?? {
     title: `Acompanhantes em ${capitalizedCity} | Perfis Verificados`,
@@ -487,12 +801,11 @@ export async function generateMetadata({
   };
 }
 
-// ─── Sub-components ───────────────────────────────────────────────────────────
+// ── Sub-components ────────────────────────────────────────────────────────────
 
 function LocationH1({ citySlug }: { citySlug: string }) {
   const cityKey = citySlug.toLowerCase();
-  const capitalizedCity =
-    citySlug.charAt(0).toUpperCase() + citySlug.slice(1).replaceAll('-', ' ');
+  const capitalizedCity = formatCitySlug(cityKey);
   const h1Text =
     cityMetadata[cityKey]?.h1 ?? `Acompanhantes em ${capitalizedCity}`;
   return <h1 className="text-3xl font-bold mb-6">{h1Text}</h1>;
@@ -512,11 +825,13 @@ function CityEditorialAndFAQ({ citySlug }: { citySlug: string }) {
   const data = cityMetadata[citySlug.toLowerCase()];
   if (!data?.editorial && !data?.faq) return null;
 
-  const faqSchema = data.faq
+  const { editorial, faq } = data;
+
+  const faqSchema = faq
     ? {
         '@context': 'https://schema.org',
         '@type': 'FAQPage',
-        mainEntity: data.faq.map((item) => ({
+        mainEntity: faq.map((item) => ({
           '@type': 'Question',
           name: item.q,
           acceptedAnswer: {
@@ -529,14 +844,11 @@ function CityEditorialAndFAQ({ citySlug }: { citySlug: string }) {
 
   return (
     <div className="mt-10 mb-6">
-      {/* ── Editorial block ───────────────────────────────────────────── */}
-      {data.editorial && (
-        <div className="mb-10">
-          <h2 className="text-xl font-bold mb-5">
-            {data.editorial.mainHeading}
-          </h2>
+      {editorial && (
+        <section className="mb-10">
+          <h2 className="text-xl font-bold mb-5">{editorial.mainHeading}</h2>
 
-          {data.editorial.sections.map((section, si) => (
+          {editorial.sections.map((section, si) => (
             <div key={si} className="mb-5">
               {section.heading && (
                 <h3 className="text-base font-semibold mb-2 text-foreground">
@@ -554,36 +866,36 @@ function CityEditorialAndFAQ({ citySlug }: { citySlug: string }) {
             </div>
           ))}
 
-          {data.editorial.nearbyLinks.length > 0 && (
+          {editorial.nearbyLinks.length > 0 && (
             <p className="text-sm text-muted-foreground leading-relaxed mt-4">
               Se está a explorar outras opções em Portugal, encontra também
               perfis activos em{' '}
-              {data.editorial.nearbyLinks.map((link, idx) => (
-                <span key={link.slug}>
-                  <Link
-                    href={`/location/${link.slug}`}
-                    className="text-rose-500 hover:underline"
-                  >
-                    {link.city}
-                  </Link>
-                  {idx < data.editorial!.nearbyLinks.length - 2
-                    ? ', '
-                    : idx === data.editorial!.nearbyLinks.length - 2
-                    ? ' e '
-                    : '.'}
-                </span>
-              ))}
+              {editorial.nearbyLinks.map((link, idx) => {
+                const total = editorial.nearbyLinks.length;
+                const separator =
+                  idx < total - 2 ? ', ' : idx === total - 2 ? ' e ' : '.';
+                return (
+                  <span key={link.slug}>
+                    <Link
+                      href={`/location/${link.slug}`}
+                      className="text-rose-500 hover:underline"
+                    >
+                      {link.city}
+                    </Link>
+                    {separator}
+                  </span>
+                );
+              })}
             </p>
           )}
-        </div>
+        </section>
       )}
 
-      {/* ── FAQ block ─────────────────────────────────────────────────── */}
-      {data.faq && data.faq.length > 0 && (
-        <div className="mt-8">
+      {faq && faq.length > 0 && (
+        <section className="mt-8">
           <h2 className="text-xl font-bold mb-5">Perguntas frequentes</h2>
           <div className="space-y-5">
-            {data.faq.map((item, idx) => (
+            {faq.map((item, idx) => (
               <div key={idx}>
                 <h3 className="text-sm font-semibold mb-1 text-foreground">
                   {item.q}
@@ -601,7 +913,7 @@ function CityEditorialAndFAQ({ citySlug }: { citySlug: string }) {
               dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
             />
           )}
-        </div>
+        </section>
       )}
     </div>
   );
@@ -620,7 +932,7 @@ async function PaginationComponent({
   return <Pagination totalPages={totalPages} />;
 }
 
-// ─── Page ─────────────────────────────────────────────────────────────────────
+// ── Page ──────────────────────────────────────────────────────────────────────
 
 export default async function CompanionsPage({
   params,
@@ -630,20 +942,16 @@ export default async function CompanionsPage({
   searchParams: Promise<FilterTypesCompanions>;
 }) {
   const [{ city }, sParams] = await Promise.all([params, searchParams]);
-  const page = parseInt(sParams.page ?? '1');
+  const parsedPage = Number.parseInt(sParams.page ?? '1', 10);
+  const page = Number.isFinite(parsedPage) && parsedPage > 0 ? parsedPage : 1;
 
   return (
     <div className="container mx-auto px-10 py-8">
-      {/* H1 */}
       <LocationH1 citySlug={city} />
 
-      {/* Quick explore links */}
       <div className="mb-4 text-sm text-muted-foreground flex gap-2">
         Explorar:
-        <Link
-          href="/location/lisboa"
-          className="hover:underline text-rose-500"
-        >
+        <Link href="/location/lisboa" className="hover:underline text-rose-500">
           Lisboa
         </Link>{' '}
         |
@@ -656,15 +964,13 @@ export default async function CompanionsPage({
         </Link>
       </div>
 
-      {/* ── POSIÇÃO 1: Intro paragraph (above carousel) ─────────────── */}
+      {/* POSICAO 1: Intro paragraph - acima do carrossel */}
       <CityIntro citySlug={city} />
 
-      {/* VIP carousel */}
       <div className="mb-8">
         <HeroCarouselWrapper citySlug={city} plans={[PlanType.VIP]} />
       </div>
 
-      {/* Filters + profile list */}
       <CompanionFilters initialFilters={sParams} />
       <Suspense
         key={JSON.stringify(sParams)}
@@ -673,10 +979,9 @@ export default async function CompanionsPage({
         <CompanionsList location={city} page={page} filters={sParams} />
       </Suspense>
 
-      {/* ── POSIÇÃO 2: Editorial + FAQ (below profiles) ──────────────── */}
+      {/* POSICAO 2: Editorial + FAQ - abaixo dos perfis */}
       <CityEditorialAndFAQ citySlug={city} />
 
-      {/* Pagination */}
       <Suspense
         key={JSON.stringify(sParams) + '-pagination'}
         fallback={


### PR DESCRIPTION
## Resumo

Adiciona conteúdo editorial SEO-otimizado para 12 cidades portuguesas na página `/location/[city]`, expandindo a profundidade editorial para além do conteúdo mínimo (title + description + H1) que existia antes.

## Cidades cobertas (12)

**Norte e Centro Litoral**
- Porto, Braga, Aveiro, Coimbra, Viana do Castelo

**Lisboa**
- Lisboa

**Interior Norte e Centro**
- Vila Real, Guarda, Castelo Branco

**Alentejo**
- Évora, Beja, Portalegre

## Estrutura aplicada a cada cidade

Cada uma das 12 cidades recebeu:

- **Title tag** otimizado (`Acompanhantes em [Cidade] | Perfis Verificados`)
- **Meta description** com keyword principal + diferencial regional
- **H1** consistente
- **Intro** (~120 palavras) com keyword no primeiro parágrafo
- **Bloco editorial** com `mainHeading` + 3 seções temáticas:
  1. Contexto da cidade e procura por acompanhantes
  2. Diferencial da plataforma na região
  3. Discrição, privacidade e contexto hoteleiro local
- **Nearby links** (3 cidades próximas) para reforço de link interno
- **FAQ** com 4–5 perguntas cobrindo: como encontrar, verificação de perfis, disponibilidade, legalidade, escorts de luxo

## Cidades ainda sem tratamento editorial

Mantidas com estrutura mínima (title + description + H1), para serem cobertas em próximos PRs:

- Faro
- Viseu
- Leiria
- Setúbal
- Santarém
- Bragança

## Impacto esperado

- Aumento de profundidade temática para Google e ranqueamento por keywords long-tail (`acompanhantes de luxo em [cidade]`, `escorts em [cidade]`)
- Melhor cobertura E-E-A-T com conteúdo contextual sobre cada região (Beira Baixa, Alto Alentejo, Trás-os-Montes, etc.)
- FAQ blocks elegíveis para FAQ rich snippets quando schema JSON-LD estiver implementado
- Link interno reforçado via `nearbyLinks` entre cidades da mesma região

## Arquivos alterados

- `app/location/[city]/page.tsx` (+397 / −92)

## Testado

- [ ] Build local sem erros TypeScript
- [ ] Navegação manual em pelo menos 3 cidades (sugestão: Porto, Évora, Guarda)
- [ ] Verificação de que cidades não-editadas continuam renderizando normalmente