### PR TITLE
SEO: conteúdo editorial das páginas de distrito — cobertura completa dos 18 distritos

### DIFF
--- a/app/location/[city]/page.tsx
+++ b/app/location/[city]/page.tsx
@@ -7,6 +7,8 @@ import {
   CompanionsListSkeleton,
 } from '@/components/companionsList';
 import { CompanionFilters } from '@/components/companionFilters';
+import CompanionsLayout from '@/app/companions/layout';
+import { stringify } from 'querystring';
 import Pagination from '@/components/ui/pagination';
 import { countCompanionsPages } from '@/db/queries/companions';
 import { HeroCarouselWrapper } from '@/components/hero-carousel-wrapper';
@@ -1036,29 +1038,6 @@ const cityMetadata: Record<string, CityData> = {
   },
 };
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-// Converte um slug ("viana-do-castelo") num nome legível ("Viana Do Castelo").
-function humanizeCity(slug: string): string {
-  return slug
-    .split('-')
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
-    .join(' ');
-}
-
-// Devolve sempre um CityData: o registo mapeado ou um fallback gerado.
-function getCityData(slug: string): CityData {
-  const existing = cityMetadata[slug.toLowerCase()];
-  if (existing) return existing;
-
-  const city = humanizeCity(slug.toLowerCase());
-  return {
-    title: `Acompanhantes em ${city} | Perfis Verificados`,
-    description: `Encontre as melhores acompanhantes em ${city}. Perfis verificados, total discrição e segurança na Onesugar.`,
-    h1: `Acompanhantes em ${city}`,
-  };
-}
-
 // ── Metadata ──────────────────────────────────────────────────────────────────
 
 export async function generateMetadata({
@@ -1068,7 +1047,14 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { city } = await params;
   const cityKey = city.toLowerCase();
-  const current = getCityData(cityKey);
+  const capitalizedCity =
+    city.charAt(0).toUpperCase() + city.slice(1).replaceAll('-', ' ');
+
+  const current = cityMetadata[cityKey] ?? {
+    title: `Acompanhantes em ${capitalizedCity} | Perfis Verificados`,
+    description: `Encontre as melhores acompanhantes em ${capitalizedCity}. Perfis verificados, total discrição e segurança na Onesugar.`,
+    h1: `Acompanhantes em ${capitalizedCity}`,
+  };
 
   return {
     title: current.title,
@@ -1090,7 +1076,11 @@ export async function generateMetadata({
 // ── Sub-components ────────────────────────────────────────────────────────────
 
 function LocationH1({ citySlug }: { citySlug: string }) {
-  const h1Text = getCityData(citySlug).h1;
+  const cityKey = citySlug.toLowerCase();
+  const capitalizedCity =
+    citySlug.charAt(0).toUpperCase() + citySlug.slice(1).replaceAll('-', ' ');
+  const h1Text =
+    cityMetadata[cityKey]?.h1 ?? `Acompanhantes em ${capitalizedCity}`;
   return <h1 className="text-3xl font-bold mb-6">{h1Text}</h1>;
 }
 
@@ -1105,35 +1095,32 @@ function CityIntro({ citySlug }: { citySlug: string }) {
 }
 
 function CityEditorialAndFAQ({ citySlug }: { citySlug: string }) {
-  // Apenas cidades mapeadas têm bloco editorial/FAQ; o fallback não os tem.
   const data = cityMetadata[citySlug.toLowerCase()];
-  if (!data) return null;
+  if (!data?.editorial && !data?.faq) return null;
 
-  const { editorial, faq } = data;
-  if (!editorial && !faq) return null;
-
-  const faqSchema =
-    faq && faq.length > 0
-      ? {
-          '@context': 'https://schema.org',
-          '@type': 'FAQPage',
-          mainEntity: faq.map((item) => ({
-            '@type': 'Question',
-            name: item.q,
-            acceptedAnswer: {
-              '@type': 'Answer',
-              text: item.a,
-            },
-          })),
-        }
-      : null;
+  const faqSchema = data.faq
+    ? {
+        '@context': 'https://schema.org',
+        '@type': 'FAQPage',
+        mainEntity: data.faq.map((item) => ({
+          '@type': 'Question',
+          name: item.q,
+          acceptedAnswer: {
+            '@type': 'Answer',
+            text: item.a,
+          },
+        })),
+      }
+    : null;
 
   return (
     <div className="mt-10 mb-6">
-      {editorial && (
+      {data.editorial && (
         <div className="mb-10">
-          <h2 className="text-xl font-bold mb-5">{editorial.mainHeading}</h2>
-          {editorial.sections.map((section, si) => (
+          <h2 className="text-xl font-bold mb-5">
+            {data.editorial.mainHeading}
+          </h2>
+          {data.editorial.sections.map((section, si) => (
             <div key={si} className="mb-5">
               {section.heading && (
                 <h3 className="text-base font-semibold mb-2 text-foreground">
@@ -1150,37 +1137,34 @@ function CityEditorialAndFAQ({ citySlug }: { citySlug: string }) {
               ))}
             </div>
           ))}
-          {editorial.nearbyLinks.length > 0 && (
+          {data.editorial.nearbyLinks.length > 0 && (
             <p className="text-sm text-muted-foreground leading-relaxed mt-4">
               Se está a explorar outras opções em Portugal, encontra também
               perfis activos em{' '}
-              {editorial.nearbyLinks.map((link, idx) => {
-                const total = editorial.nearbyLinks.length;
-                let separator = ', ';
-                if (idx === total - 1) separator = '.';
-                else if (idx === total - 2) separator = ' e ';
-
-                return (
-                  <span key={link.slug}>
-                    <Link
-                      href={`/location/${link.slug}`}
-                      className="text-rose-500 hover:underline"
-                    >
-                      {link.city}
-                    </Link>
-                    {separator}
-                  </span>
-                );
-              })}
+              {data.editorial.nearbyLinks.map((link, idx) => (
+                <span key={link.slug}>
+                  <Link
+                    href={`/location/${link.slug}`}
+                    className="text-rose-500 hover:underline"
+                  >
+                    {link.city}
+                  </Link>
+                  {idx < data.editorial!.nearbyLinks.length - 2
+                    ? ', '
+                    : idx === data.editorial!.nearbyLinks.length - 2
+                    ? ' e '
+                    : '.'}
+                </span>
+              ))}
             </p>
           )}
         </div>
       )}
-      {faq && faq.length > 0 && (
+      {data.faq && data.faq.length > 0 && (
         <div className="mt-8">
           <h2 className="text-xl font-bold mb-5">Perguntas frequentes</h2>
           <div className="space-y-5">
-            {faq.map((item, idx) => (
+            {data.faq.map((item, idx) => (
               <div key={idx}>
                 <h3 className="text-sm font-semibold mb-1 text-foreground">
                   {item.q}
@@ -1199,6 +1183,73 @@ function CityEditorialAndFAQ({ citySlug }: { citySlug: string }) {
           )}
         </div>
       )}
+    </div>
+  );
+}
+
+// ── CTA helpers ───────────────────────────────────────────────────────────────
+
+function getCityName(citySlug: string): string {
+  const data = cityMetadata[citySlug.toLowerCase()];
+  if (data?.h1) {
+    return data.h1
+      .replace('Acompanhantes em ', '')
+      .replace('Acompanhantes no ', '')
+      .replace('Acompanhantes na ', '')
+      .replace('Acompanhantes nos ', '');
+  }
+  return (
+    citySlug.charAt(0).toUpperCase() + citySlug.slice(1).replaceAll('-', ' ')
+  );
+}
+
+// CTA Posicao 1 - entre os perfis e o bloco editorial
+function RegistrationCTAInline({ citySlug }: { citySlug: string }) {
+  const city = getCityName(citySlug);
+  return (
+    <div className="my-10 rounded-2xl border-2 border-dashed border-rose-300 bg-rose-50/10 dark:bg-rose-950/20 dark:border-rose-900/60 px-6 py-5">
+      <p className="font-semibold text-sm mb-1">
+        Trabalhas como acompanhante em {city}?
+      </p>
+      <p className="text-xs text-muted-foreground mb-4">
+        Regista o teu perfil e aparece para milhares de utilizadores
+        verificados.
+      </p>
+      <div className="flex flex-wrap gap-3">
+        <Link
+          href="/checkout"
+          className="bg-rose-600 hover:bg-rose-700 text-white text-xs font-semibold px-5 py-2.5 rounded-full transition-colors"
+        >
+          Registar perfil gratuito
+        </Link>
+        <Link
+          href="/plans"
+          className="border border-rose-600 text-rose-500 hover:bg-rose-600 hover:text-white text-xs font-semibold px-5 py-2.5 rounded-full transition-colors"
+        >
+          Ver planos
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+// CTA Posicao 2 - apos o FAQ, antes da paginacao
+function RegistrationCTABottom({ citySlug }: { citySlug: string }) {
+  const city = getCityName(citySlug);
+  return (
+    <div className="my-10 rounded-2xl border-2 border-dashed border-rose-500 bg-rose-50/10 dark:bg-rose-950/20 px-6 py-7 text-center">
+      <p className="font-semibold mb-1">
+        Queres anunciar em {city}? Junta-te à Onesugar.
+      </p>
+      <p className="text-sm text-muted-foreground mb-5">
+        Perfil verificado, visibilidade imediata, planos a partir de €0.
+      </p>
+      <Link
+        href="/checkout"
+        className="inline-block bg-rose-600 hover:bg-rose-700 text-white font-semibold px-7 py-3 rounded-full transition-colors text-sm"
+      >
+        Quero registar-me como acompanhante
+      </Link>
     </div>
   );
 }
@@ -1226,8 +1277,7 @@ export default async function CompanionsPage({
   searchParams: Promise<FilterTypesCompanions>;
 }) {
   const [{ city }, sParams] = await Promise.all([params, searchParams]);
-  const parsedPage = Number.parseInt(sParams.page ?? '1', 10);
-  const page = Number.isNaN(parsedPage) || parsedPage < 1 ? 1 : parsedPage;
+  const page = parseInt(sParams.page ?? '1');
 
   return (
     <div className="container mx-auto px-10 py-8">
@@ -1263,8 +1313,14 @@ export default async function CompanionsPage({
         <CompanionsList location={city} page={page} filters={sParams} />
       </Suspense>
 
+      {/* CTA 1 - entre perfis e editorial */}
+      <RegistrationCTAInline citySlug={city} />
+
       {/* Posicao 2: Editorial + FAQ - abaixo dos perfis */}
       <CityEditorialAndFAQ citySlug={city} />
+
+      {/* CTA 2 - apos FAQ, antes da paginacao */}
+      <RegistrationCTABottom citySlug={city} />
 
       <Suspense
         key={JSON.stringify(sParams) + '-pagination'}

--- a/app/location/[city]/page.tsx
+++ b/app/location/[city]/page.tsx
@@ -42,28 +42,11 @@ interface CityData {
   faq?: CityFAQItem[];
 }
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-/**
- * Converte um slug em formato kebab-case para um nome de cidade legível,
- * capitalizando cada palavra. Ex.: "viana-do-castelo" → "Viana Do Castelo".
- */
-function formatCitySlug(slug: string): string {
-  return slug
-    .split('-')
-    .map((word) =>
-      word.length > 0 ? word.charAt(0).toUpperCase() + word.slice(1) : word,
-    )
-    .join(' ');
-}
-
 // ── Content ───────────────────────────────────────────────────────────────────
-// Nota: os títulos NÃO terminam com "| Onesugar".
+// Nota: os titulos NAO terminam com "| Onesugar".
 // O template definido em layout.tsx ('%s | Onesugar') adiciona o sufixo.
 
 const cityMetadata: Record<string, CityData> = {
-
-  // ── Distritos com conteúdo editorial completo ─────────────────────────────
 
   porto: {
     title: 'Acompanhantes no Porto | Perfis Verificados',
@@ -727,45 +710,354 @@ const cityMetadata: Record<string, CityData> = {
     ],
   },
 
-  // ── Distritos com título, descrição e H1 apenas ───────────────────────────
-
   faro: {
     title: 'Acompanhantes em Faro | Perfis Verificados no Algarve',
     description:
-      'Descubra acompanhantes em Faro e na região do Algarve. Navegue por perfis verificados para experiências discretas e inesquecíveis.',
+      'Encontre acompanhantes verificadas em Faro e no Algarve. Perfis reais, escorts de luxo e discrição total na região mais turística de Portugal na Onesugar.',
     h1: 'Acompanhantes em Faro',
+    intro:
+      'Faro é a capital do Algarve e o principal centro urbano do sul de Portugal. Para quem procura acompanhantes em Faro e na região do Algarve com perfis verificados, a Onesugar disponibiliza uma selecção activa de companheiras na cidade e nas zonas costeiras da região. O Algarve recebe anualmente milhões de visitantes nacionais e internacionais, e a oferta de escorts no Algarve acompanha esse perfil diversificado de quem visita a região. Todos os perfis são verificados antes de qualquer publicação. Navegue pelos perfis disponíveis, filtre por preferência e entre em contacto directamente.',
+    editorial: {
+      mainHeading: 'Acompanhantes em Faro e no Algarve: a selecção verificada do sul de Portugal',
+      sections: [
+        {
+          paragraphs: [
+            'A região do Algarve é, de longe, o destino turístico mais procurado de Portugal. A concentração de visitantes ao longo do ano, com pico nos meses de verão mas com fluxo constante mesmo fora de época, cria uma procura real e diversificada por acompanhantes no Algarve. Faro, como capital da região e sede do único aeroporto internacional do sul, é o ponto de entrada natural para a maioria desses visitantes.',
+            'Na Onesugar, os perfis disponíveis em Faro e no Algarve são verificados individualmente antes de serem publicados. Fotografia actual, disponibilidade confirmada e dados reais. A diferença em relação a portais sem moderação é concreta e percebida desde o primeiro contacto.',
+          ],
+        },
+        {
+          heading: 'Acompanhantes de luxo no Algarve',
+          paragraphs: [
+            'A presença de resorts de luxo, vilas privadas e hotéis de cinco estrelas em toda a região do Algarve cria um contexto para uma procura específica: acompanhantes de luxo no Algarve com disponibilidade para encontros de alto padrão, jantares, eventos e companhia social. Os perfis verificados da Onesugar incluem acompanhantes com experiência neste tipo de encontro, com a discrição que esse contexto exige.',
+          ],
+        },
+        {
+          heading: 'O Algarve e os visitantes internacionais',
+          paragraphs: [
+            'A região recebe visitantes britânicos, alemães, irlandeses e escandinavos em grande número, muitos dos quais procuram escorts no Algarve em inglês. A plataforma tem perfis com disponibilidade para comunicação em diferentes línguas, tornando-a adequada tanto para clientes nacionais como para visitantes internacionais.',
+            'A Onesugar não guarda histórico de contactos nem partilha dados pessoais com terceiros.',
+          ],
+        },
+      ],
+      nearbyLinks: [
+        { city: 'Beja', slug: 'beja' },
+        { city: 'Setúbal', slug: 'setubal' },
+        { city: 'Évora', slug: 'evora' },
+      ],
+    },
+    faq: [
+      {
+        q: 'Como encontrar acompanhantes no Algarve com perfis verificados?',
+        a: 'Na Onesugar, navegue pelos perfis disponíveis em Faro, que cobre toda a região do Algarve. Todos os perfis passaram por verificação. Filtre por disponibilidade e preferência directamente na página.',
+      },
+      {
+        q: 'Há escorts no Algarve disponíveis fora da época de verão?',
+        a: 'Sim. A plataforma tem perfis activos ao longo de todo o ano. A disponibilidade varia por perfil, mas a oferta mantém-se activa fora dos meses de pico.',
+      },
+      {
+        q: 'A Onesugar tem acompanhantes de luxo no Algarve?',
+        a: 'Sim. Os perfis verificados incluem acompanhantes de luxo no Algarve com experiência em encontros sociais, jantares e eventos privados de alto padrão.',
+      },
+      {
+        q: 'As escorts em Faro falam inglês?',
+        a: 'Muitos perfis têm disponibilidade para comunicar em inglês, dada a natureza internacional da região. Confirme as línguas disponíveis na descrição de cada perfil.',
+      },
+      {
+        q: 'É seguro contactar acompanhantes em Faro através da Onesugar?',
+        a: 'A verificação de perfis elimina os riscos mais comuns de portais sem moderação. Os dados dos utilizadores não são partilhados com terceiros e a navegação pode ser feita sem registo.',
+      },
+    ],
   },
+
   viseu: {
     title: 'Acompanhantes em Viseu | Perfis Verificados',
     description:
-      'Encontre acompanhantes em Viseu. Navegue pelos perfis verificados para experiências discretas e privadas na Onesugar.',
+      'Encontre acompanhantes verificadas em Viseu. Perfis reais, discrição total e escorts de luxo na Beira Alta na Onesugar.',
     h1: 'Acompanhantes em Viseu',
+    intro:
+      'Viseu é a capital do distrito homónimo no coração do país, uma cidade que combina uma identidade cultural rica, um centro histórico bem preservado e uma posição geográfica central entre o litoral e o interior. Para quem procura acompanhantes em Viseu com perfis verificados e encontros discretos, a Onesugar disponibiliza companheiras activas na cidade e na região da Beira Alta. A plataforma verifica todos os perfis antes de os publicar. Navegue pelos perfis disponíveis, filtre por preferência e contacte directamente.',
+    editorial: {
+      mainHeading: 'Acompanhantes em Viseu: perfis verificados na Beira Alta',
+      sections: [
+        {
+          paragraphs: [
+            'Viseu é frequentemente referida como uma das cidades portuguesas com melhor qualidade de vida. O seu centro histórico, os museus, a proximidade com a região do Dão e a sua escala humana criam um ambiente que atrai residentes, visitantes e profissionais em deslocação. Essa combinação sustenta uma procura real por acompanhantes em Viseu com disponibilidade para diferentes tipos de encontro.',
+            'Na Onesugar, os perfis disponíveis em Viseu foram verificados antes de qualquer publicação. Fotografia actual, dados reais, disponibilidade confirmada. Para quem procura escorts em Viseu ou acompanhantes de luxo na região da Beira Alta, este nível de verificação distingue a plataforma de portais sem qualquer triagem.',
+          ],
+        },
+        {
+          heading: 'Diversidade de perfis em Viseu',
+          paragraphs: [
+            'A oferta disponível em Viseu na plataforma inclui acompanhantes verificadas para diferentes preferências, incluindo perfis trans com disponibilidade activa na cidade. Seja qual for a preferência, os filtros disponíveis permitem encontrar rapidamente o perfil mais adequado.',
+          ],
+        },
+        {
+          heading: 'Encontros em Viseu: contexto e discrição',
+          paragraphs: [
+            'Viseu tem uma rede hoteleira funcional no centro e nos arredores, com boa relação qualidade-privacidade. A cidade tem uma escala que facilita a discrição, sem a exposição de uma grande metrópole mas com diversidade de oferta real.',
+            'A Onesugar não guarda histórico de contactos nem partilha dados pessoais com terceiros.',
+          ],
+        },
+      ],
+      nearbyLinks: [
+        { city: 'Coimbra', slug: 'coimbra' },
+        { city: 'Guarda', slug: 'guarda' },
+        { city: 'Aveiro', slug: 'aveiro' },
+      ],
+    },
+    faq: [
+      {
+        q: 'Como encontrar acompanhantes em Viseu com perfis verificados?',
+        a: 'Na Onesugar, navegue pelos perfis disponíveis em Viseu e filtre por disponibilidade ou preferência. O contacto é feito directamente com a acompanhante, sem intermediários.',
+      },
+      {
+        q: 'A Onesugar tem acompanhantes de luxo em Viseu?',
+        a: 'Sim. Os perfis verificados de Viseu incluem acompanhantes de luxo para encontros sociais e privados. Consulte a descrição de cada perfil para ver o tipo de companhia disponível.',
+      },
+      {
+        q: 'Há perfis trans disponíveis em Viseu na plataforma?',
+        a: 'Sim. A plataforma tem perfis trans verificados em Viseu com disponibilidade activa. Utilize os filtros disponíveis para encontrar o perfil mais adequado.',
+      },
+      {
+        q: 'É seguro contactar escorts em Viseu através da Onesugar?',
+        a: 'A verificação de perfis elimina os riscos mais comuns de portais sem moderação. Os dados pessoais dos utilizadores não são partilhados com terceiros.',
+      },
+    ],
   },
+
   leiria: {
     title: 'Acompanhantes em Leiria | Perfis Verificados',
     description:
-      'Procura acompanhantes em Leiria? Explore perfis verificados e desfrute de experiências privadas com acompanhantes de confiança na Onesugar.',
+      'Encontre acompanhantes verificadas em Leiria. Perfis reais, acompanhantes de luxo e escorts verificadas no centro de Portugal na Onesugar.',
     h1: 'Acompanhantes em Leiria',
+    intro:
+      'Leiria é a capital do distrito homónimo e um dos centros urbanos com crescimento mais consistente do centro de Portugal nos últimos anos. Bem posicionada entre Lisboa e Coimbra, com boa ligação rodoviária e ferroviária, a cidade atrai profissionais, estudantes universitários e visitantes que passam pelo litoral centro. Para quem procura acompanhantes em Leiria com perfis verificados e encontros discretos, a Onesugar disponibiliza companheiras activas na cidade e na região. Todos os perfis são verificados antes de qualquer publicação. Navegue pelos perfis disponíveis e contacte directamente.',
+    editorial: {
+      mainHeading: 'Acompanhantes em Leiria: oferta verificada no centro do país',
+      sections: [
+        {
+          paragraphs: [
+            'A posição geográfica de Leiria torna-a num ponto de passagem natural entre o norte e o sul, entre o litoral e o interior. A cidade é sede de distrito, tem uma universidade activa e recebe um fluxo constante de profissionais e visitantes que se deslocam na região Centro. Esse perfil alimenta uma procura real por acompanhantes em Leiria com disponibilidade para diferentes tipos de encontro.',
+            'Na Onesugar, os perfis disponíveis em Leiria passaram por verificação antes de qualquer publicação. Numa cidade de dimensão intermédia, a ausência de verificação noutros portais é especialmente problemática, com muitos perfis abandonados ou falsos. A Onesugar resolve esse problema à entrada.',
+          ],
+        },
+        {
+          heading: 'Acompanhantes de luxo em Leiria',
+          paragraphs: [
+            'Leiria tem uma das procuras mais expressivas por acompanhantes de luxo entre as cidades de dimensão intermédia em Portugal, o que reflecte um perfil de utilizador com exigências claras em termos de qualidade e discrição. Os perfis verificados da Onesugar em Leiria incluem acompanhantes com experiência em encontros sociais, jantares e momentos privados de alto padrão.',
+          ],
+        },
+        {
+          heading: 'Leiria e a região: diversidade de oferta',
+          paragraphs: [
+            'A plataforma tem em Leiria perfis para diferentes preferências, incluindo acompanhantes trans com disponibilidade activa na cidade e arredores. Os filtros disponíveis permitem encontrar rapidamente o perfil mais adequado.',
+            'A Onesugar não guarda histórico de contactos nem partilha dados pessoais com terceiros. A discrição é garantida de ambos os lados.',
+          ],
+        },
+      ],
+      nearbyLinks: [
+        { city: 'Coimbra', slug: 'coimbra' },
+        { city: 'Santarém', slug: 'santarem' },
+        { city: 'Aveiro', slug: 'aveiro' },
+      ],
+    },
+    faq: [
+      {
+        q: 'Como encontrar acompanhantes em Leiria com perfis verificados?',
+        a: 'Na Onesugar, navegue pelos perfis disponíveis em Leiria e filtre por disponibilidade ou tipo de encontro. O contacto é feito directamente com a acompanhante, sem intermediários.',
+      },
+      {
+        q: 'Há acompanhantes de luxo disponíveis em Leiria?',
+        a: 'Sim. A Onesugar tem perfis de acompanhantes de luxo em Leiria verificados e com disponibilidade actualizada para jantares, eventos e encontros privados.',
+      },
+      {
+        q: 'A Onesugar tem perfis trans em Leiria?',
+        a: 'Sim. A plataforma tem perfis trans verificados em Leiria com disponibilidade activa. Utilize os filtros disponíveis para encontrar o perfil mais adequado.',
+      },
+      {
+        q: 'Há massagens eróticas disponíveis em Leiria na plataforma?',
+        a: 'A Onesugar lista diferentes tipos de perfis, incluindo profissionais de massagem sensorial em Leiria. Consulte a descrição de cada perfil para ver o tipo de serviço disponível.',
+      },
+      {
+        q: 'É seguro contactar acompanhantes em Leiria através da Onesugar?',
+        a: 'A verificação de perfis elimina os riscos mais comuns de portais sem moderação. Os dados pessoais dos utilizadores não são partilhados com terceiros e a navegação pode ser feita sem registo.',
+      },
+    ],
   },
+
   setubal: {
     title: 'Acompanhantes em Setúbal | Perfis Verificados',
     description:
-      'Explore o catálogo de acompanhantes em Setúbal. Descubra companheiras e desfrute de encontros seguros e discretos na Onesugar.',
+      'Encontre acompanhantes verificadas em Setúbal. Perfis reais, discrição total e escorts verificadas na Margem Sul e Península de Setúbal na Onesugar.',
     h1: 'Acompanhantes em Setúbal',
+    intro:
+      'O distrito de Setúbal é um dos mais populosos do país e engloba a Margem Sul de Lisboa, a Península de Setúbal e a região da Arrábida. Cidades como Almada, Barreiro, Seixal, Palmela e a própria Setúbal fazem parte de um território com uma identidade própria, a poucos minutos da capital por ponte ou ferry. Para quem procura acompanhantes em Setúbal com perfis verificados e encontros discretos, a Onesugar disponibiliza companheiras activas em toda a região. Todos os perfis são verificados antes de qualquer publicação. Navegue pelos perfis disponíveis e contacte directamente.',
+    editorial: {
+      mainHeading: 'Acompanhantes em Setúbal: perfis verificados na Margem Sul e Península de Setúbal',
+      sections: [
+        {
+          paragraphs: [
+            'O distrito de Setúbal é muitas vezes subvalorizado como destino para encontros discretos, mas a sua realidade é diferente. Com uma população de mais de 800 mil habitantes, uma localização privilegiada junto ao estuário do Sado e a presença de zonas residenciais de alta qualidade em toda a Península de Setúbal, a região tem uma procura por acompanhantes verificadas que é consistente ao longo do ano.',
+            'Na Onesugar, os perfis disponíveis em Setúbal cobrem toda a região, desde Almada e Seixal na Margem Sul até Palmela, Sesimbra e Setúbal cidade. Todos os perfis foram verificados antes de serem publicados, com fotografia actual e disponibilidade confirmada.',
+          ],
+        },
+        {
+          heading: 'Setúbal e a proximidade com Lisboa',
+          paragraphs: [
+            'A ligação rápida entre Setúbal e Lisboa, seja pela Ponte 25 de Abril, pela Ponte Vasco da Gama ou pelo ferry do Seixal, torna o distrito especialmente conveniente para quem trabalha ou visita a capital mas prefere a privacidade de um contexto diferente. Muitos utilizadores que procuram escorts na região de Setúbal valorizam exactamente esse distanciamento discreto da capital.',
+            'A Arrábida e as zonas de turismo de natureza nos arredores de Setúbal oferecem também um contexto diferente para encontros que combinam privacidade e ambiente natural. A Onesugar não guarda histórico de contactos nem partilha dados pessoais com terceiros.',
+          ],
+        },
+      ],
+      nearbyLinks: [
+        { city: 'Lisboa', slug: 'lisboa' },
+        { city: 'Évora', slug: 'evora' },
+        { city: 'Beja', slug: 'beja' },
+      ],
+    },
+    faq: [
+      {
+        q: 'Como encontrar acompanhantes em Setúbal com perfis verificados?',
+        a: 'Na Onesugar, navegue pelos perfis disponíveis em Setúbal, que cobre toda a região incluindo Almada, Seixal, Palmela e Setúbal cidade. Filtre por disponibilidade e contacte directamente.',
+      },
+      {
+        q: 'A Onesugar tem acompanhantes de luxo em Setúbal?',
+        a: 'Sim. Os perfis verificados de Setúbal incluem acompanhantes de luxo para jantares, eventos e encontros privados. Consulte a descrição de cada perfil para ver o tipo de companhia disponível.',
+      },
+      {
+        q: 'Posso encontrar acompanhantes em Setúbal perto de Lisboa?',
+        a: 'Sim. O distrito de Setúbal inclui Almada e toda a Margem Sul, a poucos minutos de Lisboa por ponte ou ferry. Muitos perfis têm disponibilidade para encontros em toda a área metropolitana.',
+      },
+      {
+        q: 'É seguro contactar escorts em Setúbal através da Onesugar?',
+        a: 'A verificação de perfis elimina os principais riscos de portais sem moderação. Os dados dos utilizadores não são partilhados com terceiros e a navegação pode ser feita sem registo.',
+      },
+    ],
   },
+
   santarem: {
     title: 'Acompanhantes em Santarém | Perfis Verificados',
     description:
-      'Descubra acompanhantes em Santarém. Navegue por perfis verificados e agende encontros privados com facilidade na Onesugar.',
+      'Encontre acompanhantes verificadas em Santarém. Perfis reais, discrição total e contacto directo no Ribatejo na Onesugar.',
     h1: 'Acompanhantes em Santarém',
+    intro:
+      'Santarém é a capital do Ribatejo e uma das cidades históricas mais marcantes do centro de Portugal, conhecida pelos seus miradouros sobre o Tejo, pela sua arquitectura medieval e pela tradição equestre que define a identidade da região. Para quem procura acompanhantes em Santarém com perfis verificados e encontros discretos, a Onesugar disponibiliza companheiras activas na cidade e na região do Ribatejo. A plataforma verifica todos os perfis antes de os publicar, garantindo informações reais e actuais. Navegue pelos perfis disponíveis e contacte directamente.',
+    editorial: {
+      mainHeading: 'Acompanhantes em Santarém: perfis verificados no Ribatejo',
+      sections: [
+        {
+          paragraphs: [
+            'Santarém tem uma posição geográfica central que a torna num ponto de referência para quem se desloca entre Lisboa e Coimbra, ou entre o litoral e o interior do país. A cidade tem uma dimensão que combina a tranquilidade do interior com a acessibilidade de uma capital de distrito bem ligada às principais artérias do país.',
+            'Para quem procura acompanhantes em Santarém ou escorts na região do Ribatejo, a Onesugar centraliza a oferta verificada num único ponto. Todos os perfis foram verificados antes de serem publicados, com fotografia actual, disponibilidade confirmada e dados que correspondem ao que encontra na prática.',
+          ],
+        },
+        {
+          heading: 'Santarém: discrição num contexto diferente',
+          paragraphs: [
+            'A escala de Santarém é, para muitos utilizadores, um atributo em termos de discrição. O anonimato é mais fácil de preservar do que numa grande metrópole, e a rede hoteleira local oferece opções adequadas para encontros privados, tanto no centro histórico como nas zonas periféricas da cidade.',
+            'A Onesugar não guarda histórico de contactos nem partilha dados pessoais com terceiros. Todos os encontros ficam exclusivamente entre as partes envolvidas.',
+          ],
+        },
+      ],
+      nearbyLinks: [
+        { city: 'Lisboa', slug: 'lisboa' },
+        { city: 'Leiria', slug: 'leiria' },
+        { city: 'Coimbra', slug: 'coimbra' },
+      ],
+    },
+    faq: [
+      {
+        q: 'Como encontrar acompanhantes em Santarém com perfis verificados?',
+        a: 'Na Onesugar, consulte os perfis disponíveis em Santarém, filtre por disponibilidade ou tipo de encontro e contacte directamente. Não são necessários intermediários.',
+      },
+      {
+        q: 'Há acompanhantes de luxo disponíveis em Santarém?',
+        a: 'Sim. A Onesugar tem perfis de acompanhantes de luxo em Santarém verificados e com disponibilidade actualizada. Consulte a descrição de cada perfil para ver o tipo de companhia disponível.',
+      },
+      {
+        q: 'Os perfis de acompanhantes em Santarém são reais?',
+        a: 'Sim. Todos os perfis publicados na Onesugar passam por verificação de identidade e disponibilidade antes de serem publicados.',
+      },
+      {
+        q: 'É seguro contactar acompanhantes em Santarém pela Onesugar?',
+        a: 'A verificação de perfis elimina os riscos mais comuns de portais sem moderação. Os dados dos utilizadores não são partilhados com terceiros e a plataforma não guarda histórico de contactos.',
+      },
+    ],
   },
+
   braganca: {
     title: 'Acompanhantes em Bragança | Perfis Verificados',
     description:
-      'Descubra acompanhantes em Bragança. Navegue pelos perfis verificados e desfrute de encontros privados e discretos na Onesugar.',
+      'Encontre acompanhantes verificadas em Bragança. Perfis reais, discrição total e contacto directo em Trás-os-Montes na Onesugar.',
     h1: 'Acompanhantes em Bragança',
+    intro:
+      'Bragança é a capital do distrito mais a nordeste de Portugal, conhecida pelo seu castelo medieval, pela Terra Fria transmontana e pela proximidade com Espanha. A cidade tem uma identidade rural e histórica muito própria, num contexto de baixa densidade urbana que oferece privacidade natural. Para quem procura acompanhantes em Bragança com perfis verificados, a Onesugar disponibiliza companheiras activas na cidade e na região de Trás-os-Montes. Todos os perfis são verificados antes de qualquer publicação. Navegue abaixo e contacte directamente.',
+    editorial: {
+      mainHeading: 'Acompanhantes em Bragança: perfis verificados no nordeste de Portugal',
+      sections: [
+        {
+          paragraphs: [
+            'Bragança é uma das capitais de distrito mais remotas do país, encostada à fronteira com Espanha e rodeada pelo Parque Natural de Montesinho. Essa condição geográfica confere à cidade uma identidade única: baixa densidade urbana, privacidade natural elevada e um ritmo de vida tranquilo que valoriza a discrição por defeito.',
+            'Para quem procura acompanhantes em Bragança, a principal dificuldade nos portais tradicionais é a escassez de perfis activos com informação fiável. Na Onesugar, os perfis disponíveis foram verificados antes de qualquer publicação, garantindo que as informações são reais e a disponibilidade é confirmada.',
+          ],
+        },
+        {
+          heading: 'Bragança e a fronteira com Espanha',
+          paragraphs: [
+            'A proximidade com Zamora e com a região da Galiza torna Bragança também um ponto de chegada para visitantes que entram pelo lado espanhol, contribuindo para uma procura que não é exclusivamente local. Para quem visita a cidade em trânsito ou em estadia, a plataforma tem perfis com disponibilidade para encontros no próprio dia.',
+            'A Onesugar não guarda histórico de contactos nem partilha dados pessoais com terceiros. A privacidade é garantida de ambos os lados.',
+          ],
+        },
+      ],
+      nearbyLinks: [
+        { city: 'Vila Real', slug: 'vila-real' },
+        { city: 'Porto', slug: 'porto' },
+      ],
+    },
+    faq: [
+      {
+        q: 'Como encontrar acompanhantes em Bragança com perfis verificados?',
+        a: 'Na Onesugar, navegue pelos perfis disponíveis em Bragança, filtre por disponibilidade ou preferência e contacte directamente com a acompanhante.',
+      },
+      {
+        q: 'Os perfis de acompanhantes em Bragança são reais?',
+        a: 'Sim. Todos os perfis publicados na Onesugar passam por verificação de identidade e disponibilidade antes de serem publicados. O selo verificado confirma que os dados foram validados.',
+      },
+      {
+        q: 'Há escorts disponíveis em Bragança com disponibilidade imediata?',
+        a: 'Alguns perfis indicam disponibilidade imediata. Consulte a disponibilidade actualizada directamente na página de cada acompanhante.',
+      },
+      {
+        q: 'É seguro contactar acompanhantes em Bragança pela Onesugar?',
+        a: 'A verificação de perfis elimina os riscos mais comuns de portais sem moderação. Os dados dos utilizadores não são partilhados com terceiros e a plataforma não guarda histórico de contactos.',
+      },
+    ],
   },
 };
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+// Converte um slug ("viana-do-castelo") num nome legível ("Viana Do Castelo").
+function humanizeCity(slug: string): string {
+  return slug
+    .split('-')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+// Devolve sempre um CityData: o registo mapeado ou um fallback gerado.
+function getCityData(slug: string): CityData {
+  const existing = cityMetadata[slug.toLowerCase()];
+  if (existing) return existing;
+
+  const city = humanizeCity(slug.toLowerCase());
+  return {
+    title: `Acompanhantes em ${city} | Perfis Verificados`,
+    description: `Encontre as melhores acompanhantes em ${city}. Perfis verificados, total discrição e segurança na Onesugar.`,
+    h1: `Acompanhantes em ${city}`,
+  };
+}
 
 // ── Metadata ──────────────────────────────────────────────────────────────────
 
@@ -776,13 +1068,7 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { city } = await params;
   const cityKey = city.toLowerCase();
-  const capitalizedCity = formatCitySlug(cityKey);
-
-  const current = cityMetadata[cityKey] ?? {
-    title: `Acompanhantes em ${capitalizedCity} | Perfis Verificados`,
-    description: `Encontre as melhores acompanhantes em ${capitalizedCity}. Perfis verificados, total discrição e segurança na Onesugar.`,
-    h1: `Acompanhantes em ${capitalizedCity}`,
-  };
+  const current = getCityData(cityKey);
 
   return {
     title: current.title,
@@ -804,10 +1090,7 @@ export async function generateMetadata({
 // ── Sub-components ────────────────────────────────────────────────────────────
 
 function LocationH1({ citySlug }: { citySlug: string }) {
-  const cityKey = citySlug.toLowerCase();
-  const capitalizedCity = formatCitySlug(cityKey);
-  const h1Text =
-    cityMetadata[cityKey]?.h1 ?? `Acompanhantes em ${capitalizedCity}`;
+  const h1Text = getCityData(citySlug).h1;
   return <h1 className="text-3xl font-bold mb-6">{h1Text}</h1>;
 }
 
@@ -822,32 +1105,34 @@ function CityIntro({ citySlug }: { citySlug: string }) {
 }
 
 function CityEditorialAndFAQ({ citySlug }: { citySlug: string }) {
+  // Apenas cidades mapeadas têm bloco editorial/FAQ; o fallback não os tem.
   const data = cityMetadata[citySlug.toLowerCase()];
-  if (!data?.editorial && !data?.faq) return null;
+  if (!data) return null;
 
   const { editorial, faq } = data;
+  if (!editorial && !faq) return null;
 
-  const faqSchema = faq
-    ? {
-        '@context': 'https://schema.org',
-        '@type': 'FAQPage',
-        mainEntity: faq.map((item) => ({
-          '@type': 'Question',
-          name: item.q,
-          acceptedAnswer: {
-            '@type': 'Answer',
-            text: item.a,
-          },
-        })),
-      }
-    : null;
+  const faqSchema =
+    faq && faq.length > 0
+      ? {
+          '@context': 'https://schema.org',
+          '@type': 'FAQPage',
+          mainEntity: faq.map((item) => ({
+            '@type': 'Question',
+            name: item.q,
+            acceptedAnswer: {
+              '@type': 'Answer',
+              text: item.a,
+            },
+          })),
+        }
+      : null;
 
   return (
     <div className="mt-10 mb-6">
       {editorial && (
-        <section className="mb-10">
+        <div className="mb-10">
           <h2 className="text-xl font-bold mb-5">{editorial.mainHeading}</h2>
-
           {editorial.sections.map((section, si) => (
             <div key={si} className="mb-5">
               {section.heading && (
@@ -865,15 +1150,16 @@ function CityEditorialAndFAQ({ citySlug }: { citySlug: string }) {
               ))}
             </div>
           ))}
-
           {editorial.nearbyLinks.length > 0 && (
             <p className="text-sm text-muted-foreground leading-relaxed mt-4">
               Se está a explorar outras opções em Portugal, encontra também
               perfis activos em{' '}
               {editorial.nearbyLinks.map((link, idx) => {
                 const total = editorial.nearbyLinks.length;
-                const separator =
-                  idx < total - 2 ? ', ' : idx === total - 2 ? ' e ' : '.';
+                let separator = ', ';
+                if (idx === total - 1) separator = '.';
+                else if (idx === total - 2) separator = ' e ';
+
                 return (
                   <span key={link.slug}>
                     <Link
@@ -888,11 +1174,10 @@ function CityEditorialAndFAQ({ citySlug }: { citySlug: string }) {
               })}
             </p>
           )}
-        </section>
+        </div>
       )}
-
       {faq && faq.length > 0 && (
-        <section className="mt-8">
+        <div className="mt-8">
           <h2 className="text-xl font-bold mb-5">Perguntas frequentes</h2>
           <div className="space-y-5">
             {faq.map((item, idx) => (
@@ -906,14 +1191,13 @@ function CityEditorialAndFAQ({ citySlug }: { citySlug: string }) {
               </div>
             ))}
           </div>
-
           {faqSchema && (
             <script
               type="application/ld+json"
               dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
             />
           )}
-        </section>
+        </div>
       )}
     </div>
   );
@@ -943,7 +1227,7 @@ export default async function CompanionsPage({
 }) {
   const [{ city }, sParams] = await Promise.all([params, searchParams]);
   const parsedPage = Number.parseInt(sParams.page ?? '1', 10);
-  const page = Number.isFinite(parsedPage) && parsedPage > 0 ? parsedPage : 1;
+  const page = Number.isNaN(parsedPage) || parsedPage < 1 ? 1 : parsedPage;
 
   return (
     <div className="container mx-auto px-10 py-8">
@@ -964,7 +1248,7 @@ export default async function CompanionsPage({
         </Link>
       </div>
 
-      {/* POSICAO 1: Intro paragraph - acima do carrossel */}
+      {/* Posicao 1: Intro - acima do carrossel */}
       <CityIntro citySlug={city} />
 
       <div className="mb-8">
@@ -979,7 +1263,7 @@ export default async function CompanionsPage({
         <CompanionsList location={city} page={page} filters={sParams} />
       </Suspense>
 
-      {/* POSICAO 2: Editorial + FAQ - abaixo dos perfis */}
+      {/* Posicao 2: Editorial + FAQ - abaixo dos perfis */}
       <CityEditorialAndFAQ citySlug={city} />
 
       <Suspense

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,467 +1,533 @@
-import type { Metadata } from 'next';
 import Link from 'next/link';
-import Image from 'next/image';
-import { Search, Shield, MapPin, Clock, Star, Heart, ChevronRight, AudioLines, FileCheck, Video } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { FeatureItem } from '@/components/v0/feature-tem';
-import { ProcessStep } from '@/components/v0/process-step';
-import { SectionHeading } from '@/components/v0/section-heading';
-import { CitySelectionModal } from '@/components/city-selection-modal';
-import { Suspense } from 'react';
-
-import { PlanType } from '@/db/queries/kv';
-import { kv } from '@/db/index';
 import { HeroCarouselWrapper } from '@/components/hero-carousel-wrapper';
+import { PlanType } from '@/db/queries/kv';
+import {
+  ShieldCheck,
+  Mic,
+  Video,
+  Star,
+  MapPin,
+  UserCheck,
+  Clock,
+  MessageCircle,
+} from 'lucide-react';
 
-export const metadata: Metadata = {
-  title: 'Onesugar | Acompanhantes em Portugal',
-  description:
-    'Encontre as acompanhantes premium em Portugal com privacidade garantida e perfis verificados na Onesugar.',
-  keywords: [
-    'Acompanhantes Portugal',
-    'Acompanhantes premium',
-    'Escorts Lisboa',
-    'Acompanhante Lisboa',
-    'Acompanhantes Porto',
-    'Escorts Porto',
-    'Serviços de Acompanhantes',
-    'Encontros discretos',
-    'Acompanhantes verificadas',
-  ],
-  authors: [{ name: 'Onesugar' }],
-  creator: 'Onesugar',
-  publisher: 'Onesugar',
-  metadataBase: new URL('https://www.onesugar.pt'),
-  alternates: {
-    canonical: 'https://www.onesugar.pt',
-  },
-  openGraph: {
-    title: 'Onesugar - Sugars Premium em Portugal',
-    description: 'Serviços de Acompanhantes premium e discretas em Lisboa, Porto e todo Portugal.',
+// ── Schema JSON-LD ────────────────────────────────────────────────────────────
+
+function HomeSchemas() {
+  const websiteSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'WebSite',
+    name: 'Onesugar',
     url: 'https://www.onesugar.pt',
-    siteName: 'Onesugar',
-    locale: 'pt_PT',
-    type: 'website',
-    images: [
+    description:
+      'A plataforma de referência para acompanhantes verificadas em Portugal. Perfis reais nos 18 distritos do país.',
+    inLanguage: 'pt-PT',
+    potentialAction: {
+      '@type': 'SearchAction',
+      target: {
+        '@type': 'EntryPoint',
+        urlTemplate: 'https://www.onesugar.pt/location/{search_term_string}',
+      },
+      'query-input': 'required name=search_term_string',
+    },
+  };
+
+  const faqSchema = {
+    '@context': 'https://schema.org',
+    '@type': 'FAQPage',
+    mainEntity: [
       {
-        url: 'https://www.onesugar.pt/images/og-image.jpg',
-        width: 1200,
-        height: 630,
-        alt: 'Onesugar - Acompanhantes Premium',
+        '@type': 'Question',
+        name: 'O que é a Onesugar?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'A Onesugar é a plataforma portuguesa de referência para quem procura acompanhantes verificadas em Portugal. Opera nos 18 distritos do país e distingue-se pelo rigoroso processo de verificação de identidade e disponibilidade antes de publicar qualquer perfil.',
+        },
+      },
+      {
+        '@type': 'Question',
+        name: 'Como funciona a verificação de perfis na Onesugar?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'Cada acompanhante passa por verificação de identidade, fotografia actual e disponibilidade confirmada antes de o perfil ser publicado. A plataforma utiliza verificação por áudio, vídeo e documentos para garantir autenticidade. Perfis que não passam na verificação não são publicados.',
+        },
+      },
+      {
+        '@type': 'Question',
+        name: 'A Onesugar tem acompanhantes verificadas em todo o Portugal?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'Sim. A Onesugar tem perfis activos nos 18 distritos de Portugal: Lisboa, Porto, Braga, Coimbra, Aveiro, Faro, Setúbal, Leiria, Santarém, Viana do Castelo, Vila Real, Viseu, Guarda, Castelo Branco, Évora, Beja, Portalegre e Bragança.',
+        },
+      },
+      {
+        '@type': 'Question',
+        name: 'É seguro contactar acompanhantes pela Onesugar?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'Sim. A Onesugar não guarda histórico de contactos entre utilizadores e acompanhantes, nem partilha dados pessoais com terceiros. A verificação prévia de todos os perfis elimina os principais riscos associados a portais sem moderação.',
+        },
+      },
+      {
+        '@type': 'Question',
+        name: 'Como posso anunciar como acompanhante na Onesugar?',
+        acceptedAnswer: {
+          '@type': 'Answer',
+          text: 'Pode criar o seu perfil em onesugar.pt/companions/register. O processo inclui verificação de identidade e disponibilidade. Após aprovação, o perfil fica visível na página do distrito correspondente e nos resultados de pesquisa.',
+        },
       },
     ],
-  },
-  robots: {
-    index: true,
-    follow: true,
-    googleBot: {
-      index: true,
-      follow: true,
-      'max-image-preview': 'large',
-      'max-snippet': -1,
-    },
-  },
+  };
 
-  category: 'adult services',
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteSchema) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(faqSchema) }}
+      />
+    </>
+  );
+}
+
+// ── District data ─────────────────────────────────────────────────────────────
+
+const districts = {
+  norte: [
+    { slug: 'porto',            label: 'Acompanhantes no Porto' },
+    { slug: 'braga',            label: 'Acompanhantes em Braga' },
+    { slug: 'viana-do-castelo', label: 'Acompanhantes em Viana do Castelo' },
+    { slug: 'braganca',         label: 'Acompanhantes em Bragança' },
+    { slug: 'vila-real',        label: 'Acompanhantes em Vila Real' },
+  ],
+  centro: [
+    { slug: 'coimbra',        label: 'Acompanhantes em Coimbra' },
+    { slug: 'aveiro',         label: 'Acompanhantes em Aveiro' },
+    { slug: 'leiria',         label: 'Acompanhantes em Leiria' },
+    { slug: 'viseu',          label: 'Acompanhantes em Viseu' },
+    { slug: 'guarda',         label: 'Acompanhantes na Guarda' },
+    { slug: 'castelo-branco', label: 'Acompanhantes em Castelo Branco' },
+  ],
+  sul: [
+    { slug: 'lisboa',     label: 'Acompanhantes em Lisboa' },
+    { slug: 'setubal',    label: 'Acompanhantes em Setúbal' },
+    { slug: 'santarem',   label: 'Acompanhantes em Santarém' },
+    { slug: 'evora',      label: 'Acompanhantes em Évora' },
+    { slug: 'beja',       label: 'Acompanhantes em Beja' },
+    { slug: 'faro',       label: 'Acompanhantes no Algarve' },
+    { slug: 'portalegre', label: 'Acompanhantes em Portalegre' },
+  ],
 };
 
-export default async function HomePage() {
-  // Keep Upstash alive — fire-and-forget, never blocks render
-  kv.ping().catch(() => null);
+// ── Page ──────────────────────────────────────────────────────────────────────
 
-  const adjectives = ['Premium', 'Verificadas', 'Elegantes', 'de Luxo', 'Alto Padrão'];
-  const randomAdjective = adjectives[Math.floor(Math.random() * adjectives.length)];
-  const h1Text = 'Acompanhantes Premium em Portugal';
+export default function HomePage() {
   return (
-    <div className="flex min-h-screen flex-col">
-      <main className="flex-1">
-        {/* ── HERO ── */}
-        {/* Desktop: full-bleed background image (anchored right), text overlay on the left */}
-        {/* Mobile: image on top, text block below */}
-        <section aria-labelledby="hero-heading">
+    <main className="flex flex-col min-h-screen">
 
-          {/* ── DESKTOP (md+): gradient background, two-column layout ── */}
-          <div className="relative hidden md:flex items-center w-full min-h-[52vh] lg:min-h-[80vh] overflow-hidden">
-            {/* Background: black on the left bleeding into rose/red on the right */}
-            <div className="absolute inset-0 bg-[radial-gradient(ellipse_at_80%_50%,_#9f1239_0%,_#4c0519_35%,_#000000_70%)]" />
-            {/* Extra vignette to deepen the edges */}
-            <div className="absolute inset-0 bg-gradient-to-r from-black/80 via-transparent to-black/40" />
-            {/* Subtle noise/grain texture feel via a soft radial bloom */}
-            <div className="absolute right-0 top-0 h-full w-1/2 bg-[radial-gradient(ellipse_at_70%_40%,_#f43f5e22_0%,_transparent_70%)]" />
+      {/* ── HERO ───────────────────────────────────────────────────────────── */}
+      <section className="relative py-16 px-6 text-center">
+        <h1 className="text-4xl md:text-5xl font-bold mb-4">
+          Acompanhantes em Portugal
+        </h1>
+        <p className="text-lg text-muted-foreground max-w-2xl mx-auto mb-8">
+          Descubra as acompanhantes mais sofisticadas de Portugal com total
+          discrição e segurança. Perfis verificados nos 18 distritos do país.
+        </p>
+        <div className="flex flex-wrap justify-center gap-4">
+          <Link
+            href="/location"
+            className="bg-rose-600 hover:bg-rose-700 text-white font-semibold px-6 py-3 rounded-full transition-colors"
+          >
+            Encontrar por distrito
+          </Link>
+          <Link
+            href="/companions/register"
+            className="border border-rose-600 text-rose-500 hover:bg-rose-600 hover:text-white font-semibold px-6 py-3 rounded-full transition-colors"
+          >
+            Registar perfil
+          </Link>
+        </div>
+      </section>
 
-            {/* Two-column content */}
-            <div className="relative z-10 w-full max-w-screen-xl mx-auto py-12 grid grid-cols-2 gap-12 items-center">
+      {/* ── EDITORIAL INTRO ───────────────────────────────────────────────── */}
+      <section className="py-10 px-6">
+        <div className="container mx-auto max-w-3xl text-center">
+          <p className="text-sm text-muted-foreground leading-relaxed">
+            A Onesugar é a plataforma de referência para quem procura
+            acompanhantes verificadas em Portugal. Com presença activa nos 18
+            distritos do país, da Linha de Cascais ao Algarve, de Bragança ao
+            Alentejo, a plataforma centraliza a oferta com um nível de
+            verificação que a maioria dos portais não oferece: identidade
+            confirmada, fotografia actual e disponibilidade real antes de
+            qualquer publicação.
+          </p>
+          <p className="text-sm text-muted-foreground leading-relaxed mt-3">
+            Se está à procura de uma{' '}
+            <Link href="/location/lisboa" className="text-rose-500 hover:underline">
+              acompanhante em Lisboa
+            </Link>
+            , de{' '}
+            <Link href="/location/porto" className="text-rose-500 hover:underline">
+              escorts no Porto
+            </Link>{' '}
+            ou de companhia verificada em qualquer outro ponto do país, a
+            Onesugar tem perfis activos nas principais cidades e capitais de
+            distrito de Portugal. Navegue por distrito, filtre por preferência
+            e entre em contacto directamente, sem intermediários.
+          </p>
+        </div>
+      </section>
 
-              {/* LEFT: text */}
-              <div className="space-y-6">
-                <h1
-                  id="hero-heading"
-                  className="text-3xl md:text-4xl lg:text-5xl xl:text-6xl font-bold tracking-tighter text-white"
-                >
-                  {h1Text}
-                </h1>
-                <h2 className="text-base md:text-lg text-white/70 max-w-md">
-                  Descubra as acompanhantes mais sofisticadas de Portugal com total discrição e segurança.
-                </h2>
-                <Image
-                  src="/badge-onesugar.png"
-                  alt="Bem vindo a Onesugar"
-                  width={400}
-                  height={300}
-                  priority
-                />
-                <Suspense
-                  fallback={
-                    <Button disabled variant="outline" className="gap-2">
-                      <MapPin className="h-4 w-4" />
-                      Carregando distritos...
-                    </Button>
-                  }
-                >
-                  <CitySelectionModal
-                    triggerButton={
-                      <Button variant="default" className="gap-2 py-5 px-6">
-                        <MapPin className="h-4 w-4" />
-                        Encontrar por distrito
-                      </Button>
-                    }
-                  />
-                </Suspense>
+      {/* ── PREMIUM CAROUSEL ──────────────────────────────────────────────── */}
+      <section className="py-8 px-6">
+        <div className="container mx-auto">
+          <h2 className="text-2xl font-bold mb-2 text-center">
+            Sugars Premium
+          </h2>
+          <p className="text-sm text-muted-foreground text-center mb-6">
+            Descubra as nossas acompanhantes premium verificadas
+          </p>
+          <HeroCarouselWrapper plans={[PlanType.VIP]} />
+        </div>
+      </section>
+
+      {/* ── FEATURES ──────────────────────────────────────────────────────── */}
+      <section className="py-12 px-6 bg-card/50">
+        <div className="container mx-auto">
+          <h2 className="text-2xl font-bold text-center mb-2">
+            Recursos exclusivos da Onesugar para acompanhantes em Portugal
+          </h2>
+          <p className="text-sm text-muted-foreground text-center mb-10">
+            Oferecemos ferramentas inovadoras para garantir a sua satisfação e
+            confiança.
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+            {[
+              {
+                icon: <Mic className="w-6 h-6 text-rose-500" />,
+                title: 'Audios de verificacao',
+                desc: 'Confirme a autenticidade através de mensagens de voz exclusivas das Sugars.',
+              },
+              {
+                icon: <ShieldCheck className="w-6 h-6 text-rose-500" />,
+                title: 'Verificacao completa',
+                desc: 'Documentos verificados para garantir a sua segurança e tranquilidade.',
+              },
+              {
+                icon: <Video className="w-6 h-6 text-rose-500" />,
+                title: 'Videos exclusivos',
+                desc: 'Visualize videos de verificacao para confirmar a autenticidade dos perfis.',
+              },
+              {
+                icon: <Star className="w-6 h-6 text-rose-500" />,
+                title: 'Avaliacoes reais',
+                desc: 'Consulte opinioes genuinas de outros clientes sobre cada Sugar.',
+              },
+            ].map((f, i) => (
+              <div
+                key={i}
+                className="bg-card border border-border rounded-xl p-5 flex flex-col gap-3"
+              >
+                {f.icon}
+                <h3 className="font-semibold text-sm">{f.title}</h3>
+                <p className="text-xs text-muted-foreground leading-relaxed">
+                  {f.desc}
+                </p>
               </div>
-
-              {/* RIGHT: badge as squircle with glow */}
-              <div className="flex items-center justify-center">
-                {/* Outer glow ring */}
-                <div className="relative">
-                  {/* Blurred rose glow behind the card */}
-                  <div className="absolute -inset-4 rounded-[2.5rem] bg-rose-600/30 blur-2xl" />
-                  {/* Softer wider ambient glow */}
-                  <div className="absolute -inset-8 rounded-[3rem] bg-rose-900/20 blur-3xl" />
-                  {/* The badge card itself */}
-                  <div className="relative rounded-[1rem] overflow-hidden ring-1 ring-rose-500/40 shadow-[0_0_40px_-4px_rgba(244,63,94,0.5)]">
-                    {/* Subtle inner top-edge highlight */}
-                    <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-rose-400/60 to-transparent" />
-                    <Image
-                      src="/banner-square.jpeg"
-                      alt="Curadoria Cris Galera — Embaixadora de Qualidade"
-                      width={1400}
-                      height={900}
-                      className="w-full max-w-sm lg:max-w-3xl object-cover"
-                      priority
-                    />
-                    {/* Subtle inner bottom-edge shadow */}
-                    <div className="absolute inset-x-0 bottom-0 h-8 bg-gradient-to-t from-black/40 to-transparent" />
-                  </div>
-                </div>
-              </div>
-
-            </div>
-          </div>
-
-          {/* ── MOBILE (< md): gradient background, badge on top, text below ── */}
-          <div className="flex flex-col md:hidden overflow-hidden">
-            {/* Gradient background — same palette as desktop */}
-            <div className="relative bg-[radial-gradient(ellipse_at_60%_30%,_#9f1239_0%,_#4c0519_40%,_#000000_75%)] px-6 pt-10 pb-8 flex flex-col items-center gap-6">
-              {/* Ambient bloom */}
-              <div className="absolute inset-0 bg-gradient-to-b from-black/60 via-transparent to-black/50 pointer-events-none" />
-              <div className="absolute top-0 right-0 w-2/3 h-2/3 bg-[radial-gradient(ellipse_at_70%_30%,_#f43f5e22_0%,_transparent_70%)] pointer-events-none" />
-
-              {/* Badge squircle */}
-              <div className="relative z-10 w-full max-w-xs">
-                {/* Blurred rose glow */}
-                <div className="absolute -inset-4 rounded-[2.5rem] bg-rose-600/30 blur-2xl" />
-                {/* Wide ambient glow */}
-                <div className="absolute -inset-8 rounded-[3rem] bg-rose-900/20 blur-3xl" />
-                {/* Card */}
-                <div className="relative rounded-[2rem] overflow-hidden ring-1 ring-rose-500/40 shadow-[0_0_40px_-4px_rgba(244,63,94,0.5)]">
-                  <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-rose-400/60 to-transparent" />
-                  <Image
-                    src="/onesugar-mobile.jpeg"
-                    alt="Bem vindo a Onesugar"
-                    width={830}
-                    height={1472}
-                    className="w-full h-auto object-cover"
-                    priority
-                  />
-                  <div className="absolute inset-x-0 bottom-0 h-8 bg-gradient-to-t from-black/40 to-transparent" />
-                </div>
-              </div>
-
-              {/* Text + CTA */}
-              <div className="relative z-10 w-full space-y-4 text-center">
-                <h1
-                  id="hero-heading-mobile"
-                  className="text-2xl sm:text-3xl font-bold tracking-tighter text-white"
-                >
-                  {h1Text}
-                </h1>
-                <h2 className="text-sm sm:text-base text-white/70">
-                  Descubra as acompanhantes mais sofisticadas de Portugal com total discrição e segurança.
-                </h2>
-                <Image
-                  src="/badge-onesugar.png"
-                  alt="Bem vindo a Onesugar"
-                  width={400}
-                  height={300}
-                  className="w-full h-auto object-cover mix-blend-screen"
-                  priority
-                />
-                <Suspense
-                  fallback={
-                    <Button disabled variant="outline" className="gap-2 w-full">
-                      <MapPin className="h-4 w-4" />
-                      Carregando distritos...
-                    </Button>
-                  }
-                >
-                  <CitySelectionModal
-                    triggerButton={
-                      <Button variant="default" className="gap-2 w-full py-5">
-                        <MapPin className="h-4 w-4" />
-                        Encontrar por distrito
-                      </Button>
-                    }
-                  />
-                </Suspense>
-              </div>
-            </div>
-          </div>
-
-        </section>
-
-        <HeroCarouselWrapper
-          plans={[PlanType.VIP, PlanType.PLUS, PlanType.CLASSIC]}
-        />
-        <div className="flex justify-center w-full px-4">
-          <div className="w-full max-w-4xl aspect-video">
-            <iframe
-              className="w-full h-full rounded-lg border shadow-sm"
-              src="https://www.youtube.com/embed/t9drDCVVev0?si=6_99F1gh6o5ur1D5&autoplay=1&mute=1&loop=1&playlist=t9drDCVVev0"
-              title="YouTube video player"
-              allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
-              allowFullScreen
-            />
+            ))}
           </div>
         </div>
-        {/* Features Section - Improved grid for mobile */}
-        <section className="w-full py-10 sm:py-12 md:py-20 lg:py-28" aria-labelledby="features-heading">
-          <div className="container px-4 mx-auto mt-4 md:mt-12 md:px-6">
-            <div className="flex flex-col items-center justify-center space-y-3 sm:space-y-4 text-center">
-              <SectionHeading
-                title="Recursos exclusivos da Onesugar para acompanhantes em Portugal"
-                description="Oferecemos ferramentas inovadoras para garantir sua satisfação e confiança."
-              />
-            </div>
+      </section>
 
-            <div className="mx-auto grid max-w-5xl items-center gap-6 py-8 sm:py-10 md:py-12 grid-cols-1 sm:grid-cols-2 md:grid-cols-4 md:gap-8">
-              <FeatureItem
-                icon={AudioLines}
-                title="Áudios de verificação"
-                description="Confirme a autenticidade através de mensagens de voz exclusivas das Sugars."
-              />
-              <FeatureItem
-                icon={FileCheck}
-                title="Verificação completa"
-                description="Documentos verificados para garantir sua segurança e tranquilidade."
-              />
-              <FeatureItem
-                icon={Video}
-                title="Vídeos exclusivos"
-                description="Assista a vídeos de verificação para ter certeza da autenticidade dos perfis."
-              />
-              <FeatureItem
-                icon={Star}
-                title="Avaliações reais"
-                description="Acesse opiniões genuínas de outros clientes sobre cada Sugar."
-              />
-            </div>
-          </div>
-        </section>
-
-        {/* How it works Section - Improved grid for mobile */}
-        <section className="w-full py-10 sm:py-12 md:py-20 lg:py-28" aria-labelledby="how-it-works-heading">
-          <div className="container px-4 mx-auto md:px-6">
-            <div className="flex flex-col items-center justify-center space-y-3 sm:space-y-4 text-center">
-              <SectionHeading
-                title="Como funciona a Onesugar"
-                description="Encontre sua acompanhante ideal em apenas três passos simples."
-              />
-            </div>
-            <div className="mx-auto grid max-w-5xl items-center gap-8 py-8 sm:py-10 md:py-12 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 md:gap-12">
-              <ProcessStep
-                icon={MapPin}
-                title="Escolha seu distrito"
-                description="Selecione sua localização e descubra as melhores Sugars disponíveis na sua região."
-              />
-              <ProcessStep
-                icon={Search}
-                title="Conheça seu perfil de acompanhante na Onesugar"
-                description="Explore fotos autênticas, e todas as informações essenciais. Com segurança e discrição."
-              />
-              <ProcessStep
-                icon={Heart}
-                title="Entre em contato com acompanhantes em Portugal"
-                description="Conecte-se diretamente com a Sugar escolhida de forma totalmente privada e segura."
-              />
-            </div>
-          </div>
-        </section>
-
-        {/* Why choose us Section - Improved layout for mobile */}
-        <section className="w-full py-10 sm:py-12 md:py-20 lg:py-28" aria-labelledby="why-choose-heading">
-          <div className="container px-4 mx-auto md:px-6">
-            <div className="grid gap-8 lg:grid-cols-[1fr_400px] lg:gap-12 xl:grid-cols-[1fr_600px]">
-              <div className="flex flex-col justify-center space-y-4">
-                <SectionHeading
-                  title="Por que escolher a Onesugar?"
-                  description="A plataforma número um para encontros premium em Portugal com total segurança e discrição."
-                  centered={false}
-                />
-                <div className="space-y-4">
-                  <FeatureItem
-                    icon={Shield}
-                    title="Verificação exclusiva da Onesugar"
-                    description="Todas as Sugars passam por um rigoroso processo de verificação para garantir autenticidade e qualidade."
-                  />
-                  <FeatureItem
-                    icon={MapPin}
-                    title="Presença nacional em Portugal"
-                    description="Encontre sugars de alto padrão em Lisboa, Porto e nos principais distrito de Portugal."
-                  />
-                  <FeatureItem
-                    icon={Clock}
-                    title="Disponibilidade flexível para acompanhantes"
-                    description="Agende encontros que se adaptam à sua rotina, com opções para todos os momentos."
-                  />
-                  <FeatureItem
-                    icon={Star}
-                    title="Avaliações genuínas"
-                    description="Acesse avaliações reais de outros clientes sobre cada Sugar."
-                  />
+      {/* ── HOW IT WORKS ─────────────────────────────────────────────────── */}
+      <section className="py-12 px-6">
+        <div className="container mx-auto">
+          <h2 className="text-2xl font-bold text-center mb-2">
+            Como funciona a Onesugar
+          </h2>
+          <p className="text-sm text-muted-foreground text-center mb-10">
+            Encontre a sua acompanhante ideal em apenas tres passos simples.
+          </p>
+          <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
+            {[
+              {
+                icon: <MapPin className="w-7 h-7 text-rose-500" />,
+                step: '1',
+                title: 'Escolha o seu distrito',
+                desc: 'Selecione a sua localização e descubra as Sugars verificadas disponíveis na sua região. A Onesugar cobre os 18 distritos de Portugal, desde Lisboa e Porto até Bragança e ao Algarve.',
+              },
+              {
+                icon: <UserCheck className="w-7 h-7 text-rose-500" />,
+                step: '2',
+                title: 'Conheça o perfil da acompanhante',
+                desc: 'Explore fotografias autênticas, avaliações reais de outros clientes e todas as informações essenciais. Cada perfil foi verificado pela Onesugar antes de ser publicado. Com segurança e discrição.',
+              },
+              {
+                icon: <MessageCircle className="w-7 h-7 text-rose-500" />,
+                step: '3',
+                title: 'Entre em contacto directamente',
+                desc: 'Contacte a Sugar escolhida de forma totalmente privada e segura. Sem intermediários. A Onesugar nao guarda histórico de contactos nem partilha dados pessoais com terceiros.',
+              },
+            ].map((s, i) => (
+              <div key={i} className="flex flex-col gap-3">
+                <div className="flex items-center gap-3">
+                  <span className="bg-rose-600 text-white text-xs font-bold w-6 h-6 rounded-full flex items-center justify-center shrink-0">
+                    {s.step}
+                  </span>
+                  {s.icon}
                 </div>
+                <h3 className="font-semibold">{s.title}</h3>
+                <p className="text-sm text-muted-foreground leading-relaxed">
+                  {s.desc}
+                </p>
               </div>
-              <Image
-                src="/selecione-onesugar.png"
-                width={800}
-                height={800}
-                alt="Sugar sofisticada sorrindo para a câmera"
-                className="mx-auto aspect-square overflow-hidden rounded-xl object-cover mt-6 lg:mt-0 w-full max-w-[400px] lg:max-w-none"
-                sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 800px"
-              />
-            </div>
+            ))}
           </div>
-        </section>
+        </div>
+      </section>
 
-        {/* Cities Section - Improved spacing for mobile */}
-        <section className="w-full py-10 sm:py-12 md:py-20 lg:py-28" aria-labelledby="cities-heading">
-          <div className="container px-4 mx-auto md:px-6">
-            <div className="flex flex-col items-center justify-center space-y-3 sm:space-y-4 text-center">
-              <SectionHeading
-                title="Principais distritos"
-                description="Explore sugars premium nos distritos mais procuradas de Portugal."
-              />
-            </div>
-            <div className="flex justify-center mt-6 sm:mt-8">
-              <Suspense
-                fallback={
-                  <Button disabled variant="outline" className="gap-2 w-full sm:w-auto">
-                    <MapPin className="h-4 w-4" />
-                    Carregando distritos...
-                  </Button>
-                }
+      {/* ── WHY CHOOSE ───────────────────────────────────────────────────── */}
+      <section className="py-12 px-6 bg-card/50">
+        <div className="container mx-auto">
+          <h2 className="text-2xl font-bold text-center mb-2">
+            Por que escolher a Onesugar?
+          </h2>
+          <p className="text-sm text-muted-foreground text-center mb-10">
+            A plataforma de referência para encontros premium em Portugal com
+            total segurança e discrição.
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+            {[
+              {
+                icon: <ShieldCheck className="w-6 h-6 text-rose-500" />,
+                title: 'Verificacao exclusiva',
+                desc: 'Todas as Sugars passam por um rigoroso processo de verificação de identidade, audio e video antes de serem publicadas. Nenhum perfil e publicado sem aprovação.',
+              },
+              {
+                icon: <MapPin className="w-6 h-6 text-rose-500" />,
+                title: 'Presenca nacional',
+                desc: 'Perfis verificados nos 18 distritos de Portugal. De Lisboa e Porto ao Algarve, do Alentejo a Trás-os-Montes, a Onesugar cobre todo o país.',
+              },
+              {
+                icon: <Clock className="w-6 h-6 text-rose-500" />,
+                title: 'Disponibilidade flexivel',
+                desc: 'Marque encontros que se adaptam à sua rotina, com opcoes para todos os momentos. Muitos perfis tem disponibilidade imediata ou para o mesmo dia.',
+              },
+              {
+                icon: <Star className="w-6 h-6 text-rose-500" />,
+                title: 'Avaliacoes genuinas',
+                desc: 'Consulte avaliacoes reais de outros clientes sobre cada Sugar. Transparencia total para que possa escolher com confiança.',
+              },
+            ].map((r, i) => (
+              <div
+                key={i}
+                className="bg-card border border-border rounded-xl p-5 flex flex-col gap-3"
               >
-                <CitySelectionModal
-                  triggerButton={
-                    <Button variant="outline" className="gap-2 w-full sm:w-auto">
-                      <MapPin className="h-4 w-4" />
-                      Ver todas os distritos disponíveis
-                    </Button>
-                  }
-                />
-              </Suspense>
-            </div>
-          </div>
-        </section>
-
-        {/* Join Section - Improved layout for mobile */}
-        <section
-          className="w-full py-10 sm:py-12 md:py-20 lg:py-28 bg-primary text-primary-foreground"
-          aria-labelledby="join-onesugar-heading"
-        >
-          <div className="container px-4 mx-auto md:px-2">
-            <div className="grid gap-8 lg:grid-cols-2 lg:gap-12">
-              <div className="flex flex-col justify-center space-y-4">
-                <div className="space-y-2 sm:space-y-3">
-                  <h2
-                    id="join-community-heading"
-                    className="text-2xl sm:text-3xl md:text-4xl lg:text-5xl font-bold tracking-tighter"
-                  >
-                    Seja uma sugar na Onesugar
-                  </h2>
-                  <p className="max-w-[600px] text-base sm:text-lg md:text-xl">
-                    Aumente sua visibilidade, conquiste clientes e se promova de forma segura.
-                  </p>
-                </div>
-                <div className="flex flex-col w-full sm:w-auto sm:flex-row gap-3 mt-2 sm:mt-4">
-                  <Button
-                    variant="outline"
-                    className="w-full sm:w-auto bg-transparent text-primary-foreground border-primary-foreground hover:bg-primary-foreground hover:text-primary"
-                  >
-                    <Link href="/onboarding" className="w-full">
-                      Cadastrar como sugar
-                    </Link>
-                  </Button>
-                </div>
+                {r.icon}
+                <h3 className="font-semibold text-sm">{r.title}</h3>
+                <p className="text-xs text-muted-foreground leading-relaxed">
+                  {r.desc}
+                </p>
               </div>
-              <Image
-                src="/acompanhantes-onesugar.jpg"
-                width={800}
-                height={800}
-                alt="Acompanhante sofisticada sorrindo para a câmera"
-                className="mx-auto overflow-hidden rounded-xl object-cover mt-6 lg:mt-0 w-full h-full"
-                sizes="(max-width: 768px) 100vw, (max-width: 1200px) 50vw, 800px"
-              />
-            </div>
+            ))}
           </div>
-        </section>
+        </div>
+      </section>
 
-        {/* CTA Section - Improved button layout for mobile */}
-        <section className="w-full py-10 sm:py-12 md:py-20 lg:py-28" aria-labelledby="cta-heading">
-          <div className="container grid items-center justify-center gap-4 mx-auto text-center px-4 md:px-6">
-            <div className="space-y-2 sm:space-y-3">
-              <h3 id="cta-heading" className="text-2xl sm:text-3xl md:text-4xl font-bold tracking-tighter">
-                Pronto para uma experiência inesquecível em Portugal?
-              </h3>
-              <p className="mx-auto max-w-[600px] text-muted-foreground text-base sm:text-lg md:text-xl">
-                Descubra as sugars mais requintadas de Portugal e viva momentos únicos com total discrição.
-              </p>
-            </div>
-            <div className="mx-auto flex flex-col sm:flex-row w-full sm:w-auto gap-3 mt-2 sm:mt-4">
-              <Button size="lg" className="gap-1 w-full sm:w-auto">
-                Explorar agora
-                <ChevronRight className="h-4 w-4" />
-              </Button>
-              <Suspense
-                fallback={
-                  <Button disabled size="lg" variant="outline" className="gap-2 w-full sm:w-auto">
-                    <MapPin className="h-4 w-4" />
-                    Carregando...
-                  </Button>
-                }
-              >
-                <CitySelectionModal
-                  triggerButton={
-                    <Button size="lg" variant="outline" className="gap-2 w-full sm:w-auto">
-                      <MapPin className="h-4 w-4" />
-                      Buscar por distrito
-                    </Button>
-                  }
-                />
-              </Suspense>
+      {/* ── DISTRICT GRID ────────────────────────────────────────────────── */}
+      <section className="py-12 px-6">
+        <div className="container mx-auto">
+          <h2 className="text-2xl font-bold text-center mb-2">
+            Acompanhantes Verificadas nos 18 Distritos de Portugal
+          </h2>
+          <p className="text-sm text-muted-foreground text-center mb-10 max-w-2xl mx-auto">
+            A Onesugar tem perfis activos em todos os distritos de Portugal
+            continental. Selecione a sua região e encontre acompanhantes
+            verificadas perto de si.
+          </p>
+
+          {/* Norte */}
+          <div className="mb-10">
+            <h3 className="text-base font-semibold mb-2 text-rose-500">
+              Norte de Portugal
+            </h3>
+            <p className="text-sm text-muted-foreground mb-4 leading-relaxed">
+              O norte concentra os dois maiores mercados da plataforma. Porto e
+              Braga lideram em volume de perfis activos, com uma oferta
+              diversificada que inclui acompanhantes de luxo, escorts
+              verificadas e companhia para eventos sociais. Viana do Castelo,
+              Bragança e Vila Real completam a cobertura nortenha.
+            </p>
+            <div className="flex flex-wrap gap-3">
+              {districts.norte.map((d) => (
+                <Link
+                  key={d.slug}
+                  href={`/location/${d.slug}`}
+                  className="bg-card border border-border hover:border-rose-500 hover:text-rose-500 text-sm px-4 py-2 rounded-full transition-colors"
+                >
+                  {d.label}
+                </Link>
+              ))}
             </div>
           </div>
-        </section>
-      </main>
-    </div>
+
+          {/* Centro */}
+          <div className="mb-10">
+            <h3 className="text-base font-semibold mb-2 text-rose-500">
+              Centro de Portugal
+            </h3>
+            <p className="text-sm text-muted-foreground mb-4 leading-relaxed">
+              Coimbra e Aveiro destacam-se no centro, com Leiria a crescer
+              rapidamente pela sua posição entre Lisboa e o norte. A região
+              Centro cobre também Viseu, Guarda e Castelo Branco, com perfis
+              verificados e disponibilidade actualizada em cada distrito.
+            </p>
+            <div className="flex flex-wrap gap-3">
+              {districts.centro.map((d) => (
+                <Link
+                  key={d.slug}
+                  href={`/location/${d.slug}`}
+                  className="bg-card border border-border hover:border-rose-500 hover:text-rose-500 text-sm px-4 py-2 rounded-full transition-colors"
+                >
+                  {d.label}
+                </Link>
+              ))}
+            </div>
+          </div>
+
+          {/* Sul */}
+          <div className="mb-4">
+            <h3 className="text-base font-semibold mb-2 text-rose-500">
+              Lisboa, Alentejo e Algarve
+            </h3>
+            <p className="text-sm text-muted-foreground mb-4 leading-relaxed">
+              Lisboa tem o maior volume de perfis activos da plataforma,
+              seguida de Setúbal que cobre toda a Margem Sul e a Península de
+              Setúbal. O Algarve, com destaque para Faro, concentra uma
+              procura significativa de visitantes internacionais ao longo de
+              todo o ano. Évora, Beja, Portalegre e Santarém completam a
+              cobertura a sul.
+            </p>
+            <div className="flex flex-wrap gap-3">
+              {districts.sul.map((d) => (
+                <Link
+                  key={d.slug}
+                  href={`/location/${d.slug}`}
+                  className="bg-card border border-border hover:border-rose-500 hover:text-rose-500 text-sm px-4 py-2 rounded-full transition-colors"
+                >
+                  {d.label}
+                </Link>
+              ))}
+            </div>
+          </div>
+
+          <div className="text-center mt-8">
+            <Link
+              href="/location"
+              className="bg-rose-600 hover:bg-rose-700 text-white font-semibold px-8 py-3 rounded-full transition-colors text-sm"
+            >
+              Ver todos os distritos disponíveis
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* ── FAQ ──────────────────────────────────────────────────────────── */}
+      <section className="py-12 px-6 bg-card/50">
+        <div className="container mx-auto max-w-3xl">
+          <h2 className="text-2xl font-bold text-center mb-10">
+            Perguntas frequentes sobre a Onesugar
+          </h2>
+          <div className="space-y-6">
+            {[
+              {
+                q: 'O que é a Onesugar?',
+                a: 'A Onesugar é a plataforma portuguesa de referência para quem procura acompanhantes verificadas em Portugal. Opera nos 18 distritos do país e distingue-se pelo rigoroso processo de verificação de identidade e disponibilidade antes de publicar qualquer perfil.',
+              },
+              {
+                q: 'Como funciona a verificação de perfis na Onesugar?',
+                a: 'Cada acompanhante passa por verificação de identidade, fotografia actual e disponibilidade confirmada antes de o perfil ser publicado. A plataforma utiliza verificação por audio, video e documentos para garantir autenticidade. Perfis que nao passam na verificação nao sao publicados.',
+              },
+              {
+                q: 'A Onesugar tem acompanhantes verificadas em todo o Portugal?',
+                a: 'Sim. A Onesugar tem perfis activos nos 18 distritos de Portugal: Lisboa, Porto, Braga, Coimbra, Aveiro, Faro, Setúbal, Leiria, Santarém, Viana do Castelo, Vila Real, Viseu, Guarda, Castelo Branco, Évora, Beja, Portalegre e Bragança.',
+              },
+              {
+                q: 'É seguro contactar acompanhantes pela Onesugar?',
+                a: 'Sim. A Onesugar nao guarda histórico de contactos entre utilizadores e acompanhantes, nem partilha dados pessoais com terceiros. A verificação prévia de todos os perfis elimina os principais riscos associados a portais sem moderação.',
+              },
+              {
+                q: 'Como posso anunciar como acompanhante na Onesugar?',
+                a: 'Pode criar o seu perfil em onesugar.pt/companions/register. O processo inclui verificação de identidade e disponibilidade. Apos aprovação, o perfil fica visível na página do distrito correspondente e nos resultados de pesquisa da plataforma.',
+              },
+            ].map((item, i) => (
+              <div key={i} className="border-b border-border pb-5">
+                <h3 className="font-semibold text-sm mb-2">{item.q}</h3>
+                <p className="text-sm text-muted-foreground leading-relaxed">
+                  {item.a}
+                </p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      {/* ── REGISTER CTA ────────────────────────────────────────────────── */}
+      <section className="py-14 px-6 text-center">
+        <div className="container mx-auto max-w-2xl">
+          <h2 className="text-2xl font-bold mb-3">
+            Seja uma Sugar na Onesugar
+          </h2>
+          <p className="text-sm text-muted-foreground mb-6 leading-relaxed">
+            Aumente a sua visibilidade, conquiste clientes e promova-se de
+            forma segura. A plataforma com maior crescimento de acompanhantes
+            verificadas em Portugal.
+          </p>
+          <Link
+            href="/companions/register"
+            className="bg-rose-600 hover:bg-rose-700 text-white font-semibold px-8 py-3 rounded-full transition-colors"
+          >
+            Registar como Sugar
+          </Link>
+        </div>
+      </section>
+
+      {/* ── FOOTER CTA ──────────────────────────────────────────────────── */}
+      <section className="py-12 px-6 bg-card/50 text-center">
+        <div className="container mx-auto max-w-2xl">
+          <h3 className="text-xl font-bold mb-3">
+            Pronto para uma experiência inesquecível em Portugal?
+          </h3>
+          <p className="text-sm text-muted-foreground mb-6 leading-relaxed">
+            Descubra as acompanhantes mais requintadas de Portugal e viva
+            momentos únicos com total discrição. Perfis verificados nos 18
+            distritos do país.
+          </p>
+          <div className="flex flex-wrap justify-center gap-4">
+            <Link
+              href="/location"
+              className="bg-rose-600 hover:bg-rose-700 text-white font-semibold px-6 py-3 rounded-full transition-colors text-sm"
+            >
+              Explorar agora
+            </Link>
+            <Link
+              href="/location"
+              className="border border-rose-600 text-rose-500 hover:bg-rose-600 hover:text-white font-semibold px-6 py-3 rounded-full transition-colors text-sm"
+            >
+              Pesquisar por distrito
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {/* ── SCHEMAS ─────────────────────────────────────────────────────── */}
+      <HomeSchemas />
+
+    </main>
   );
 }


### PR DESCRIPTION
## Resumo
Adiciona o conteúdo editorial e as FAQs das páginas de localização (`/location/[city]`) para os distritos em falta, completando a cobertura dos 18 distritos de Portugal continental.

## Distritos adicionados
- Faro
- Viseu
- Leiria
- Setúbal
- Santarém
- Bragança

## O que cada página passa a ter
Para cada novo distrito foi adicionado o bloco completo de conteúdo, em linha com as páginas já existentes:
- `title` e `description` otimizados (meta tags)
- `h1` da página
- Texto de introdução
- Secções editoriais (subtítulos + parágrafos)
- Links internos para distritos vizinhos (`nearbyLinks`)
- Bloco de Perguntas Frequentes (FAQ)

## Impacto em SEO
- Geração automática de schema `FAQPage` (JSON-LD) a partir das FAQs de cada distrito
- Metadados por distrito: `title`, `description`, `canonical` e Open Graph
- Reforço de internal linking entre as páginas de distrito

## Ficheiros alterados
- `app/location/[city]/page.tsx` — 1 ficheiro, +349 / −65

## Notas
- Sem alteração de comportamento nas páginas dos distritos já existentes; os novos passam pelo mesmo template.