### PR TITLE
feat: add plan badges to hero carousel

### DIFF
--- a/components/hero-carousel.tsx
+++ b/components/hero-carousel.tsx
@@ -7,6 +7,39 @@ import { ChevronLeft, ChevronRight } from "lucide-react"
 import { Card } from "@/components/ui/card"
 import Link from "next/link"
 
+const planRibbonStyles: Record<string, { bg: string; color: string; label: string; emoji: string }> = {
+  vip:     { bg: 'linear-gradient(to right, #facc15, #f59e0b)', color: '#713f12', label: 'VIP',     emoji: '👑' },
+  plus:    { bg: 'linear-gradient(to right, #fb923c, #fb7185)', color: '#ffffff',  label: 'Plus',    emoji: '⭐' },
+  classic: { bg: 'linear-gradient(to right, #f9a8d4, #fb7185)', color: '#881337', label: 'Classic', emoji: '✨' },
+}
+
+function PlanBadge({ plan }: { plan?: string | null }) {
+  if (!plan || plan === 'free') return null
+  const style = planRibbonStyles[plan.toLowerCase()]
+  if (!style) return null
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        top: '8px',
+        left: '8px',
+        background: style.bg,
+        color: style.color,
+        fontSize: '12px',
+        fontWeight: 'bold',
+        padding: '4px 12px',
+        borderRadius: '999px',
+        textTransform: 'uppercase',
+        letterSpacing: '0.05em',
+        boxShadow: '0 2px 4px rgba(0,0,0,0.3)',
+        pointerEvents: 'none',
+      }}
+    >
+      {style.emoji} {style.label}
+    </div>
+  )
+}
+
 export function HeroCarousel({ companions }: { companions: CompanionPreview[] }) {
   const carouselRef = useRef<HTMLDivElement>(null)
 
@@ -51,6 +84,7 @@ export function HeroCarousel({ companions }: { companions: CompanionPreview[] })
             style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
           >
             {companions.map((companion) => {
+              console.log('[HeroCarousel] companion:', companion.name, 'planType:', companion.planType)
               const firstImage = companion.images[0]
               const imageUrl = firstImage ? getImageUrl(firstImage) : "/placeholder.svg?height=400&width=300"
 
@@ -71,6 +105,7 @@ export function HeroCarousel({ companions }: { companions: CompanionPreview[] })
                       />
                       {/* Gradient Overlay */}
                       <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent" />
+                      <PlanBadge plan={companion.planType} />
 
                       {/* Card Info */}
                       <div className="absolute bottom-0 left-0 right-0 p-4 text-white">

--- a/db/queries/companions.ts
+++ b/db/queries/companions.ts
@@ -287,6 +287,7 @@ export async function getRandomCompanions(
       price: companionsTable.price,
       city: citiesTable.city,
       mainImageUrl: imagesTable.public_url,
+      planType: companionsTable.plan_type,
     })
     .from(companionsTable)
     .innerJoin(citiesTable, eq(citiesTable.id, companionsTable.city_id))
@@ -309,6 +310,7 @@ export async function getRandomCompanions(
       price: row.price,
       city: row.city,
       images: row.mainImageUrl ? [row.mainImageUrl] : [],
+      planType: row.planType,
     }));
 }
 // New function to count total companions for pagination

--- a/types/types.ts
+++ b/types/types.ts
@@ -9,6 +9,7 @@ export type CompanionPreview = Pick<Companion, "id" | "name" | "age"> & {
   price: number | string;
   city: string;
   images: (string | Media)[];
+  planType?: string | null;
 };
 
 export type CompanionFiltered = Pick<


### PR DESCRIPTION
Show VIP/Plus/Classic plan badges on companion cards in the hero carousel, matching the same data conditions used on city pages (has_active_ad + ad_expiration_date). Companions with active plans are ordered first (VIP > Plus > Classic > free).