### PR TITLE
fix: redirect to verification page after registration and fix redirect logic

### DIFF
--- a/app/companions/register/page.tsx
+++ b/app/companions/register/page.tsx
@@ -78,8 +78,7 @@ async function CompanionFormWithData() {
     !isVerified &&
     companion &&
     allVerificationStatus.isImageUploaded &&
-    (sessionClaims.metadata.isRegistrationComplete === true) &&
-    !allVerificationStatus.isVerificationVideoUploaded
+    !allVerificationStatus.isDocumentUploaded
   ) {
     redirect("/companions/verification");
   }

--- a/components/formCompanionRegister.tsx
+++ b/components/formCompanionRegister.tsx
@@ -461,9 +461,9 @@ export function RegisterCompanionForm({
         variant: "success",
         title: "Perfil criado com sucesso",
         description:
-          "Seja bem vindo(a) à nossa plataforma. Confira nossos planos",
+          "Agora envie os documentos de verificação para ativar o seu perfil.",
       });
-      router.push("/checkout");
+      router.push("/companions/verification");
       return;
     }
     try {


### PR DESCRIPTION
After completing the registration form, redirect companions to /companions/verification instead of /checkout. Also fix the page-level redirect to use DB state (isDocumentUploaded) instead of the cached Clerk JWT isRegistrationComplete flag, which could be stale.