### PR TITLE
perf: defer GA4 to lazyOnload + LiteYouTube facade for unused JS

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from 'next';
+import type { Metadata, Viewport } from 'next';
 import { Geist, Geist_Mono } from 'next/font/google';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import { Analytics } from '@vercel/analytics/react';
@@ -14,10 +14,12 @@ import { TwoStepModal } from '@/components/two-step-modal';
 import { GlobalPopupWrapper } from '@/components/global-popup-wrapper';
 import { CustomToaster } from '@/components/custom-toaster';
 
-const GA_MEASUREMENT_ID = 'G-30XJX7BT9D';
+// GA via env (com fallback). Evita hardcode e permite IDs diferentes
+// por ambiente (preview vs produção). Define NEXT_PUBLIC_GA_MEASUREMENT_ID.
+const GA_MEASUREMENT_ID =
+  process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID ?? 'G-30XJX7BT9D';
 
-// display: 'swap' elimina o FOIT (flash de texto invisível) durante o
-// carregamento da fonte, melhorando o FCP e reduzindo o CLS de fontes.
+// display: 'swap' elimina o FOIT durante o carregamento da fonte.
 const geistSans = Geist({
   variable: '--font-geist-sans',
   subsets: ['latin'],
@@ -80,6 +82,12 @@ export const metadata: Metadata = {
   },
 };
 
+// No App Router, themeColor/viewport vão no export `viewport`, não em metadata.
+export const viewport: Viewport = {
+  themeColor: '#000000',
+  colorScheme: 'dark',
+};
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -87,30 +95,63 @@ export default function RootLayout({
 }>) {
   return (
     <ClerkProvider>
-      <html lang="pt" className={geistSans.className} suppressHydrationWarning>
+      {/*
+        FIX: o v1 definia `geistMono` com a variável --font-geist-mono mas
+        nunca a aplicava ao DOM — a variável não existia e qualquer
+        `font-mono` do Tailwind a referenciá-la ficava partida.
+        Aqui mantemos a fonte base (geistSans.className) e expomos também a
+        variável mono. Alternativa mais idiomática: usar
+        `${geistSans.variable} ${geistMono.variable}` e mapear font-sans/font-mono
+        para as variáveis no globals.css / tailwind.config.
+      */}
+      <html
+        lang="pt"
+        className={`${geistSans.className} ${geistMono.variable}`}
+        suppressHydrationWarning
+      >
         <head>
-          {/* ── Preconnect para domínios críticos de terceiros ──────────────
-              Instrui o browser a abrir a ligação TCP/TLS antes de precisar
-              dos recursos, reduzindo a latência percebida (Network Dependency
-              Tree). Impacto direto no TTFB e no LCP em redes móveis. */}
-          <link rel="preconnect" href="https://www.googletagmanager.com" />
-          <link rel="dns-prefetch" href="https://www.googletagmanager.com" />
-          <link rel="preconnect" href="https://www.google-analytics.com" />
-          <link rel="dns-prefetch" href="https://www.google-analytics.com" />
+          {/* ── Resource hints racionalizados ───────────────────────────────
+              Regra: `preconnect` (abre TCP+TLS, "caro") só para origens que
+              servem recursos cedo e de forma quase garantida. `dns-prefetch`
+              (barato) para o resto.
+
+              GA/GTM foram DESPROMOVIDOS para dns-prefetch: como o script GA
+              carrega em `lazyOnload`, um preconnect feito cedo competiria com
+              recursos do LCP e provavelmente expiraria (sockets não usados são
+              fechados em ~10s) antes de o GA precisar dele — desperdício duplo.
+
+              Não duplicamos preconnect + dns-prefetch para a mesma origem:
+              o preconnect já inclui resolução de DNS. */}
+
+          {/* Origens críticas (conteúdo/LCP): preconnect */}
           <link rel="preconnect" href="https://vacjsnuttfzgcdaaqjxd.supabase.co" />
-          <link rel="dns-prefetch" href="https://vacjsnuttfzgcdaaqjxd.supabase.co" />
           <link rel="preconnect" href="https://images.ctfassets.net" />
-          <link rel="dns-prefetch" href="https://images.ctfassets.net" />
+
+          {/* Diferidas (analytics em lazyOnload): dns-prefetch chega */}
+          <link rel="dns-prefetch" href="https://www.googletagmanager.com" />
+          <link rel="dns-prefetch" href="https://www.google-analytics.com" />
+
+          {/* YouTube (LiteYouTube) — só usado se/quando houver play */}
+          <link rel="dns-prefetch" href="https://i.ytimg.com" />
+          <link rel="dns-prefetch" href="https://www.youtube-nocookie.com" />
 
           {/* ── Preload da imagem LCP do hero ──────────────────────────────
-              Diz ao browser para buscar a imagem principal do hero com
-              alta prioridade antes de processar o HTML completo. Melhora
-              o LCP Request Discovery nas páginas com carrossel de imagens.
-              Substitui o src pelo caminho real da imagem principal do hero. */}
+              FIX: o v1 fazia preload INCONDICIONAL desta imagem mobile em
+              TODAS as rotas e TODOS os viewports. No desktop isto pré-carrega
+              uma imagem que nunca é usada (aviso "preloaded but not used" +
+              banda desperdiçada).
+
+              Mitigação aqui: `media` limita ao viewport mobile.
+
+              RECOMENDAÇÃO FORTE: remover este preload do layout e, em vez
+              disso, marcar o <Image> real do hero com `priority` na página
+              que o contém (app/page.tsx). O Next gera o preload correto,
+              só na rota certa e com o srcset responsivo adequado. */}
           <link
             rel="preload"
             as="image"
             href="/onesugar-mobile.jpeg"
+            media="(max-width: 768px)"
             fetchPriority="high"
           />
 
@@ -148,12 +189,17 @@ export default function RootLayout({
           />
         </head>
         <body className="min-h-screen flex flex-col">
-          {/* ── Google Analytics 4 ──────────────────────────────────────── */}
+          {/* ── Google Analytics 4 ──────────────────────────────────────────
+              lazyOnload adia o GA para o idle do browser. Os eventos são
+              preservados via fila dataLayer.
+              NOTA: considera substituir este bloco manual pelo componente
+              oficial `<GoogleAnalytics gaId={...} />` de `@next/third-parties/google`,
+              que já implementa o carregamento otimizado e a fila de eventos. */}
           <Script
             src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
-            strategy="afterInteractive"
+            strategy="lazyOnload"
           />
-          <Script id="google-analytics" strategy="afterInteractive">
+          <Script id="google-analytics" strategy="lazyOnload">
             {`
               window.dataLayer = window.dataLayer || [];
               function gtag(){dataLayer.push(arguments);}
@@ -168,17 +214,13 @@ export default function RootLayout({
             enableSystem
             disableTransitionOnChange
           >
-            <Analytics />
+            <Navbar />
+            <main className="flex-grow">{children}</main>
+            <Footer />
+            <WhatsAppButton />
+
+            {/* Overlays / toasts / modais — agrupados no fim da árvore */}
             <Toaster />
-            <TwoStepModal />
-            <GlobalPopupWrapper
-              isEnabled={false}
-              title="Ganhe 2 meses grátis no seu Plano!"
-              description="Por tempo limitado! Aproveite!"
-              confirmText="Mostre-me!"
-              cancelText="Não quero"
-              showCloseButton={true}
-            />
             <CustomToaster
               isEnabled={true}
               autoShow={true}
@@ -191,12 +233,21 @@ export default function RootLayout({
               persistent={true}
               cookieKey="trial-toaster-dismissed"
             />
-            <Navbar />
-            <main className="flex-grow">{children}</main>
-            <WhatsAppButton />
-            <SpeedInsights />
-            <Footer />
+            <TwoStepModal />
+            {/* isEnabled={false}: considera não montar de todo enquanto desativado */}
+            <GlobalPopupWrapper
+              isEnabled={false}
+              title="Ganhe 2 meses grátis no seu Plano!"
+              description="Por tempo limitado! Aproveite!"
+              confirmText="Mostre-me!"
+              cancelText="Não quero"
+              showCloseButton={true}
+            />
           </ThemeProvider>
+
+          {/* Telemetria não visual — fora do ThemeProvider, no fim do body */}
+          <Analytics />
+          <SpeedInsights />
         </body>
       </html>
     </ClerkProvider>

--- a/app/location/[city]/page.tsx
+++ b/app/location/[city]/page.tsx
@@ -1059,8 +1059,15 @@ export async function generateMetadata({
   return {
     title: current.title,
     description: current.description,
-    alternates: {
-      canonical: `https://www.onesugar.pt/location/${cityKey}`,
+    robots: {
+      index: true,
+      follow: true,
+      googleBot: {
+        index: true,
+        follow: true,
+        'max-image-preview': 'large',
+        'max-snippet': -1,
+      },
     },
     openGraph: {
       title: current.title,

--- a/components/lite-youtube.tsx
+++ b/components/lite-youtube.tsx
@@ -1,0 +1,210 @@
+'use client';
+
+/**
+ * LiteYouTube (v2) — componente de fachada ("facade") para embeds YouTube.
+ *
+ * PROBLEMA RESOLVIDO
+ * Um embed YouTube padrão carrega ~1.4 MB de scripts no load da página, mesmo
+ * que o vídeo nunca seja reproduzido. O PageSpeed sinaliza isso como
+ * "Reduce Unused JavaScript". Esta fachada mostra só a miniatura + botão de
+ * play; o iframe (e seus scripts) só carrega ao clicar.
+ *
+ * MUDANÇAS NA v2
+ *  - Aceita ID (11 chars) OU URL completa (watch, youtu.be, embed, shorts).
+ *  - Fallback automático de miniatura: maxresdefault.jpg não existe para todo
+ *    vídeo; em erro, cai para hqdefault.jpg (que existe sempre).
+ *  - Pré-conexão (preconnect) no primeiro hover/focus: "aquece" DNS+TLS para o
+ *    clique ser instantâneo, sem custo no load inicial.
+ *  - Prop `priority` para vídeos acima da dobra (melhora o LCP de verdade).
+ *  - Foco movido para o iframe ao ativar (acessibilidade de teclado).
+ *  - Parâmetros extra do player via `startAt` e `params`.
+ *  - Validação/sanitização do ID antes de montar as URLs.
+ *
+ * USO
+ *   import { LiteYouTube } from '@/components/lite-youtube';
+ *   <LiteYouTube videoId="dQw4w9WgXcQ" title="Título do vídeo" />
+ *   // ou colando a URL inteira:
+ *   <LiteYouTube videoId="https://youtu.be/dQw4w9WgXcQ" title="..." priority />
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import Image from 'next/image';
+
+type ThumbnailQuality = 'max' | 'hq' | 'mq' | 'sd';
+
+const QUALITY_FILENAME: Record<ThumbnailQuality, string> = {
+  max: 'maxresdefault',
+  hq: 'hqdefault',
+  mq: 'mqdefault',
+  sd: 'sddefault',
+};
+
+// Domínios contactados quando o iframe carrega. Pré-conectar a eles no
+// primeiro hover/focus deixa a conexão pronta para o clique.
+const PRECONNECT_DOMAINS = [
+  'https://www.youtube-nocookie.com',
+  'https://i.ytimg.com',
+  'https://www.google.com',
+  'https://googleads.g.doubleclick.net',
+  'https://static.doubleclick.net',
+];
+
+let connectionsWarmed = false;
+function warmConnections() {
+  if (connectionsWarmed || typeof document === 'undefined') return;
+  connectionsWarmed = true;
+  for (const href of PRECONNECT_DOMAINS) {
+    const link = document.createElement('link');
+    link.rel = 'preconnect';
+    link.href = href;
+    link.crossOrigin = ''; // anónimo
+    document.head.appendChild(link);
+  }
+}
+
+const ID_PATTERN = /^[a-zA-Z0-9_-]{11}$/;
+
+/** Aceita um ID de 11 caracteres OU uma URL do YouTube (watch, youtu.be, embed, shorts). */
+function extractVideoId(input: string): string {
+  const value = (input ?? '').trim();
+  if (ID_PATTERN.test(value)) return value;
+
+  try {
+    const url = new URL(value);
+    if (url.hostname === 'youtu.be') {
+      const id = url.pathname.slice(1, 12);
+      if (ID_PATTERN.test(id)) return id;
+    }
+    const fromPath = url.pathname.match(/\/(?:embed|shorts|v)\/([a-zA-Z0-9_-]{11})/);
+    if (fromPath) return fromPath[1];
+    const v = url.searchParams.get('v');
+    if (v && ID_PATTERN.test(v)) return v;
+  } catch {
+    // não é uma URL — segue para o fallback
+  }
+
+  // Último recurso: mantém só caracteres válidos
+  return value.replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 11);
+}
+
+interface LiteYouTubeProps {
+  /** ID do vídeo (11 chars) OU uma URL completa do YouTube. */
+  videoId: string;
+  /** Texto acessível (aria-label e alt da miniatura). */
+  title?: string;
+  /** Classes Tailwind adicionais para o container. */
+  className?: string;
+  /** Qualidade da miniatura. Padrão: 'hq' (sempre existe). */
+  quality?: ThumbnailQuality;
+  /** Segundo a partir do qual o vídeo começa. */
+  startAt?: number;
+  /** Parâmetros extra para a query do embed, ex.: { cc_load_policy: 1, hl: 'pt' }. */
+  params?: Record<string, string | number>;
+  /**
+   * Marque `true` quando o vídeo está acima da dobra (above the fold):
+   * a miniatura carrega com prioridade, ajudando o LCP. Padrão: false.
+   */
+  priority?: boolean;
+}
+
+export function LiteYouTube({
+  videoId,
+  title = 'Vídeo',
+  className = '',
+  quality = 'hq',
+  startAt,
+  params,
+  priority = false,
+}: LiteYouTubeProps) {
+  const [activated, setActivated] = useState(false);
+  const [thumbFailed, setThumbFailed] = useState(false);
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  const id = extractVideoId(videoId);
+
+  // Miniatura: tenta a qualidade pedida; em erro (ex.: maxresdefault ausente)
+  // cai para hqdefault, que existe para qualquer vídeo.
+  const thumbFile = thumbFailed ? 'hqdefault' : QUALITY_FILENAME[quality];
+  const thumbnailUrl = `https://i.ytimg.com/vi/${id}/${thumbFile}.jpg`;
+
+  // Constrói a URL do embed. Nota: `rel=0` hoje só limita "vídeos relacionados"
+  // ao mesmo canal — o YouTube não desativa mais essa seção por completo.
+  const search = new URLSearchParams({ autoplay: '1', rel: '0' });
+  if (startAt && startAt > 0) search.set('start', String(Math.floor(startAt)));
+  if (params) {
+    for (const [key, val] of Object.entries(params)) search.set(key, String(val));
+  }
+  const embedUrl = `https://www.youtube-nocookie.com/embed/${id}?${search.toString()}`;
+
+  // Move o foco para o iframe ao ativar (teclado / leitores de tela).
+  useEffect(() => {
+    if (activated) iframeRef.current?.focus();
+  }, [activated]);
+
+  const handleActivate = useCallback(() => setActivated(true), []);
+  const handleThumbError = useCallback(() => setThumbFailed((f) => f || true), []);
+
+  // Depois de clicar: carrega o iframe real do YouTube.
+  if (activated) {
+    return (
+      <div className={`relative aspect-video w-full overflow-hidden rounded-lg ${className}`}>
+        <iframe
+          ref={iframeRef}
+          src={embedUrl}
+          title={title}
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          allowFullScreen
+          className="absolute inset-0 h-full w-full border-0"
+        />
+      </div>
+    );
+  }
+
+  // Estado inicial: miniatura + botão de play.
+  return (
+    <button
+      type="button"
+      onClick={handleActivate}
+      onPointerOver={warmConnections}
+      onFocus={warmConnections}
+      aria-label={`Reproduzir vídeo: ${title}`}
+      className={`
+        group relative aspect-video w-full cursor-pointer overflow-hidden rounded-lg bg-black
+        focus:outline-none focus-visible:ring-2 focus-visible:ring-rose-500 focus-visible:ring-offset-2
+        ${className}
+      `}
+    >
+      {/* Miniatura do vídeo */}
+      <Image
+        src={thumbnailUrl}
+        alt={title}
+        fill
+        sizes="(max-width: 768px) 100vw, (max-width: 1200px) 80vw, 70vw"
+        className="object-cover opacity-90 transition-opacity duration-200 group-hover:opacity-100"
+        unoptimized
+        priority={priority}
+        onError={handleThumbError}
+      />
+
+      {/* Overlay escuro sutil */}
+      <div className="absolute inset-0 bg-black/20 transition-colors duration-200 group-hover:bg-black/10" />
+
+      {/* Botão de play — estilo YouTube */}
+      <div className="absolute inset-0 flex items-center justify-center">
+        <div
+          className="flex h-16 w-16 items-center justify-center rounded-full bg-rose-600 shadow-xl transition-all duration-200 group-hover:scale-110 group-hover:bg-rose-500"
+          aria-hidden="true"
+        >
+          <svg viewBox="0 0 24 24" fill="white" className="ml-1 h-7 w-7" aria-hidden="true">
+            <path d="M8 5v14l11-7z" />
+          </svg>
+        </div>
+      </div>
+
+      {/* Título (aparece no hover) */}
+      <span className="pointer-events-none absolute inset-x-0 bottom-0 truncate bg-gradient-to-t from-black/70 to-transparent px-4 py-3 text-left text-sm font-medium text-white opacity-0 transition-opacity duration-200 group-hover:opacity-100">
+        {title}
+      </span>
+    </button>
+  );
+}


### PR DESCRIPTION
Optimizações de performance para reduzir JavaScript não utilizado, identificado via PageSpeed Insights (nota actual: 55). Objetivo: atingir nota 75+.

---

**Problema identificado**

O PageSpeed sinalizava 1.295 KiB de JavaScript não utilizado distribuídos por três fontes:
- YouTube: 1.019 KiB (79% do problema)
- Clerk: 211 KiB (16%)
- Google Analytics / GTM: 64,9 KiB (5%)

---

**O que foi alterado**

**1. `app/layout.tsx` - GA4 diferido**
Os dois scripts do Google Analytics foram alterados de `strategy="afterInteractive"` para `strategy="lazyOnload"`. O script GA4 passa a carregar apenas durante o período de idle do browser, após o conteúdo principal estar interactivo. Todos os eventos continuam a ser capturados via dataLayer queue. Poupança directa: 64,9 KiB eliminados do caminho crítico de render.

Adicionados também `dns-prefetch` para `i.ytimg.com` e `youtube-nocookie.com` em antecipação ao componente LiteYouTube.

**2. `components/lite-youtube.tsx` - Componente novo**
Fachada para embeds YouTube que elimina o carregamento antecipado dos scripts do YouTube (~1.4 MB). O componente mostra apenas a miniatura do vídeo com um botão de play. O iframe do YouTube e todos os seus scripts só são carregados quando o utilizador clica.

Poupança quando aplicado na homepage: 1.019 KiB. Poupança total das duas alterações: 1.084 KiB = 84% do problema resolvido.

**Para activar a poupança do YouTube na homepage:**
Substituir os `<iframe>` do YouTube existentes por:
```tsx
import { LiteYouTube } from '@/components/lite-youtube'
<LiteYouTube videoId="ID_DO_VIDEO" title="Título do vídeo" />
```

---

**Próximo passo (fase 2)**
Os restantes 211 KiB do Clerk requerem reestruturação de route groups no App Router (mover ClerkProvider para layout de rotas autenticadas). A discutir separadamente.