### PR TITLE
Combine PRs #73, #74, #75, #76: Exclusiva Onesugar rename, location fixes, toast cleanup, Madeira SSG

### DIFF
--- a/app/location/[city]/page.tsx
+++ b/app/location/[city]/page.tsx
@@ -7,8 +7,6 @@ import {
   CompanionsListSkeleton,
 } from '@/components/companionsList';
 import { CompanionFilters } from '@/components/companionFilters';
-import CompanionsLayout from '@/app/companions/layout';
-import { stringify } from 'querystring';
 import Pagination from '@/components/ui/pagination';
 import { countCompanionsPages } from '@/db/queries/companions';
 import { HeroCarouselWrapper } from '@/components/hero-carousel-wrapper';
@@ -45,10 +43,12 @@ interface CityData {
 }
 
 // ── Content ───────────────────────────────────────────────────────────────────
-// Nota: os titulos NAO terminam com "| Onesugar".
+// Nota: os títulos NÃO terminam com "| Onesugar".
 // O template definido em layout.tsx ('%s | Onesugar') adiciona o sufixo.
 
 const cityMetadata: Record<string, CityData> = {
+
+  // ── Distritos com conteúdo editorial completo ─────────────────────────────
 
   porto: {
     title: 'Acompanhantes no Porto | Perfis Verificados',
@@ -1036,7 +1036,84 @@ const cityMetadata: Record<string, CityData> = {
       },
     ],
   },
+
+  // ── Região Autónoma ────────────────────────────────────────────────────────
+
+  madeira: {
+    title: 'Acompanhantes na Madeira | Perfis Verificados',
+    description:
+      'Encontre acompanhantes verificadas na Madeira. Perfis reais, discrição total e escorts de luxo na ilha mais visitada do Atlântico na Onesugar.',
+    h1: 'Acompanhantes na Madeira',
+    intro:
+      'A Madeira é um dos destinos turísticos mais procurados do mundo, conhecida pelo seu clima ameno durante todo o ano, pelas levadas, pelos picos e pela hospitalidade particular da sua gente. Para quem procura acompanhantes na Madeira com perfis verificados e encontros discretos, a Onesugar disponibiliza uma selecção de companheiras com presença activa na ilha. O Funchal, como capital e maior centro urbano, concentra a maioria dos perfis activos, com disponibilidade para encontros na cidade e em toda a ilha. Todos os perfis são verificados antes de qualquer publicação. Navegue pelos perfis disponíveis, filtre por preferência e entre em contacto directamente, sem intermediários.',
+    editorial: {
+      mainHeading: 'Acompanhantes na Madeira: perfis verificados na pérola do Atlântico',
+      sections: [
+        {
+          paragraphs: [
+            'A Madeira recebe anualmente mais de um milhão de visitantes, um número expressivo para uma ilha com cerca de 250 mil habitantes. Esse fluxo constante de turistas nacionais e internacionais, combinado com uma comunidade residente activa e uma vida nocturna centrada no Funchal, cria uma procura real e diversificada por acompanhantes na Madeira ao longo de todo o ano.',
+            'Na Onesugar, os perfis disponíveis para a Madeira foram verificados individualmente antes de serem publicados. Fotografia actual, disponibilidade confirmada e dados que correspondem ao que encontra na prática. Numa ilha onde a oferta verificada é ainda mais escassa do que no continente, esta diferença tem um impacto directo na qualidade da experiência.',
+          ],
+        },
+        {
+          heading: 'O Funchal e a procura por escorts verificadas',
+          paragraphs: [
+            'O Funchal concentra a maior parte da actividade turística e urbana da ilha. Os hotéis de cinco estrelas da zona hoteleira, os restaurantes da Zona Velha e o ambiente cosmopolita do centro da cidade criam um contexto adequado para encontros discretos de qualidade. Para quem procura acompanhantes de luxo no Funchal para um jantar, evento social ou encontro privado, os perfis verificados da Onesugar indicam claramente o tipo de companhia disponível e os contactos preferidos.',
+            'A ilha tem também zonas mais tranquilas fora do Funchal, como Câmara de Lobos, Machico e a costa norte, onde a privacidade é naturalmente mais elevada. Muitos perfis activos na plataforma têm disponibilidade para se deslocar a diferentes pontos da ilha.',
+          ],
+        },
+        {
+          heading: 'A Madeira e os visitantes internacionais',
+          paragraphs: [
+            'A ilha recebe um número significativo de visitantes britânicos, alemães, escandinavos e do mercado português continental, muitos dos quais procuram escorts na Madeira com disponibilidade para comunicar em inglês. Os perfis da Onesugar para a Madeira incluem acompanhantes com diferentes competências linguísticas, tornando a plataforma adequada tanto para clientes locais como para quem chega de fora.',
+            'A Onesugar não guarda histórico de contactos entre utilizadores e acompanhantes, nem partilha qualquer dado com terceiros. A discrição é garantida de ambos os lados.',
+          ],
+        },
+      ],
+      nearbyLinks: [
+        { city: 'Lisboa', slug: 'lisboa' },
+        { city: 'Porto', slug: 'porto' },
+        { city: 'Faro', slug: 'faro' },
+      ],
+    },
+    faq: [
+      {
+        q: 'Como encontrar acompanhantes verificadas na Madeira?',
+        a: 'Na Onesugar, navegue pelos perfis disponíveis para a Madeira e filtre por tipo de encontro, disponibilidade ou preferência. O contacto é feito directamente com a acompanhante, sem intermediários.',
+      },
+      {
+        q: 'Há acompanhantes disponíveis no Funchal?',
+        a: 'Sim. A maioria dos perfis activos na Madeira tem base no Funchal, a capital da ilha. Consulte a disponibilidade de cada perfil directamente na página para confirmar a zona de actuação.',
+      },
+      {
+        q: 'A Onesugar tem acompanhantes de luxo na Madeira?',
+        a: 'Sim. Os perfis verificados para a Madeira incluem acompanhantes de luxo com experiência em encontros sociais, jantares e eventos privados. A descrição de cada perfil especifica o tipo de companhia disponível.',
+      },
+      {
+        q: 'Há escorts na Madeira que falam inglês?',
+        a: 'Sim. Dada a natureza internacional do turismo na ilha, vários perfis têm disponibilidade para comunicar em inglês e outras línguas. Confirme as línguas disponíveis na descrição de cada perfil.',
+      },
+      {
+        q: 'É seguro contactar acompanhantes na Madeira através da Onesugar?',
+        a: 'A verificação de perfis elimina os riscos mais comuns de portais sem moderação. Os dados pessoais dos utilizadores não são partilhados com terceiros e a navegação pode ser feita sem registo.',
+      },
+      {
+        q: 'Os perfis de acompanhantes na Madeira são reais?',
+        a: 'Sim. Todos os perfis publicados na Onesugar passam por verificação de identidade e disponibilidade antes de serem publicados. O selo verificado confirma que os dados foram validados pela plataforma.',
+      },
+    ],
+  },
 };
+
+// ── Static params ─────────────────────────────────────────────────────────────
+// Pré-renderiza estaticamente todas as páginas de cidade conhecidas em build
+// time. O HTML entregue pelo servidor já contém title, description, robots e
+// canonical no <head> desde o primeiro byte, sem depender do RSC streaming.
+// Páginas com slugs fora desta lista são renderizadas on-demand (fallback SSR).
+
+export function generateStaticParams() {
+  return Object.keys(cityMetadata).map((city) => ({ city }));
+}
 
 // ── Metadata ──────────────────────────────────────────────────────────────────
 
@@ -1196,14 +1273,13 @@ function CityEditorialAndFAQ({ citySlug }: { citySlug: string }) {
 
 // ── CTA helpers ───────────────────────────────────────────────────────────────
 
-function getCityName(citySlug: string): string {
+// Retorna a preposição + nome da cidade exactamente como aparece no H1,
+// sem o prefixo "Acompanhantes". Ex.: "na Madeira", "no Porto", "em Lisboa".
+// Usado nos CTAs para evitar "em Madeira" ou "em Guarda" gramaticalmente errados.
+function getCityLabel(citySlug: string): string {
   const data = cityMetadata[citySlug.toLowerCase()];
   if (data?.h1) {
-    return data.h1
-      .replace('Acompanhantes em ', '')
-      .replace('Acompanhantes no ', '')
-      .replace('Acompanhantes na ', '')
-      .replace('Acompanhantes nos ', '');
+    return data.h1.replace(/^Acompanhantes\s+/i, '').trim();
   }
   return (
     citySlug.charAt(0).toUpperCase() + citySlug.slice(1).replaceAll('-', ' ')
@@ -1212,11 +1288,11 @@ function getCityName(citySlug: string): string {
 
 // CTA Posicao 1 - entre os perfis e o bloco editorial
 function RegistrationCTAInline({ citySlug }: { citySlug: string }) {
-  const city = getCityName(citySlug);
+  const cityLabel = getCityLabel(citySlug);
   return (
     <div className="my-10 rounded-2xl border-2 border-dashed border-rose-300 bg-rose-50/10 dark:bg-rose-950/20 dark:border-rose-900/60 px-6 py-5">
       <p className="font-semibold text-sm mb-1">
-        Trabalhas como acompanhante em {city}?
+        Trabalhas como acompanhante {cityLabel}?
       </p>
       <p className="text-xs text-muted-foreground mb-4">
         Regista o teu perfil e aparece para milhares de utilizadores
@@ -1242,11 +1318,11 @@ function RegistrationCTAInline({ citySlug }: { citySlug: string }) {
 
 // CTA Posicao 2 - apos o FAQ, antes da paginacao
 function RegistrationCTABottom({ citySlug }: { citySlug: string }) {
-  const city = getCityName(citySlug);
+  const cityLabel = getCityLabel(citySlug);
   return (
     <div className="my-10 rounded-2xl border-2 border-dashed border-rose-500 bg-rose-50/10 dark:bg-rose-950/20 px-6 py-7 text-center">
       <p className="font-semibold mb-1">
-        Queres anunciar em {city}? Junta-te à Onesugar.
+        Queres anunciar {cityLabel}? Junta-te à Onesugar.
       </p>
       <p className="text-sm text-muted-foreground mb-5">
         Perfil verificado, visibilidade imediata, planos a partir de €0.
@@ -1284,7 +1360,7 @@ export default async function CompanionsPage({
   searchParams: Promise<FilterTypesCompanions>;
 }) {
   const [{ city }, sParams] = await Promise.all([params, searchParams]);
-  const page = parseInt(sParams.page ?? '1');
+  const page = parseInt(sParams.page ?? '1', 10);
 
   return (
     <div className="container mx-auto px-10 py-8">

--- a/app/location/[city]/page.tsx
+++ b/app/location/[city]/page.tsx
@@ -42,21 +42,6 @@ interface CityData {
   faq?: CityFAQItem[];
 }
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
-/**
- * Converte um slug em formato kebab-case para um nome de cidade legível,
- * capitalizando cada palavra. Ex.: "viana-do-castelo" → "Viana Do Castelo".
- */
-function formatCitySlug(slug: string): string {
-  return slug
-    .split('-')
-    .map((word) =>
-      word.length > 0 ? word.charAt(0).toUpperCase() + word.slice(1) : word,
-    )
-    .join(' ');
-}
-
 // ── Content ───────────────────────────────────────────────────────────────────
 // Nota: os títulos NÃO terminam com "| Onesugar".
 // O template definido em layout.tsx ('%s | Onesugar') adiciona o sufixo.
@@ -727,67 +712,408 @@ const cityMetadata: Record<string, CityData> = {
     ],
   },
 
-  // ── Distritos com título, descrição e H1 apenas ───────────────────────────
-
   faro: {
     title: 'Acompanhantes em Faro | Perfis Verificados no Algarve',
     description:
-      'Descubra acompanhantes em Faro e na região do Algarve. Navegue por perfis verificados para experiências discretas e inesquecíveis.',
+      'Encontre acompanhantes verificadas em Faro e no Algarve. Perfis reais, escorts de luxo e discrição total na região mais turística de Portugal na Onesugar.',
     h1: 'Acompanhantes em Faro',
+    intro:
+      'Faro é a capital do Algarve e o principal centro urbano do sul de Portugal. Para quem procura acompanhantes em Faro e na região do Algarve com perfis verificados, a Onesugar disponibiliza uma selecção activa de companheiras na cidade e nas zonas costeiras da região. O Algarve recebe anualmente milhões de visitantes nacionais e internacionais, e a oferta de escorts no Algarve acompanha esse perfil diversificado de quem visita a região. Todos os perfis são verificados antes de qualquer publicação. Navegue pelos perfis disponíveis, filtre por preferência e entre em contacto directamente.',
+    editorial: {
+      mainHeading: 'Acompanhantes em Faro e no Algarve: a selecção verificada do sul de Portugal',
+      sections: [
+        {
+          paragraphs: [
+            'A região do Algarve é, de longe, o destino turístico mais procurado de Portugal. A concentração de visitantes ao longo do ano, com pico nos meses de verão mas com fluxo constante mesmo fora de época, cria uma procura real e diversificada por acompanhantes no Algarve. Faro, como capital da região e sede do único aeroporto internacional do sul, é o ponto de entrada natural para a maioria desses visitantes.',
+            'Na Onesugar, os perfis disponíveis em Faro e no Algarve são verificados individualmente antes de serem publicados. Fotografia actual, disponibilidade confirmada e dados reais. A diferença em relação a portais sem moderação é concreta e percebida desde o primeiro contacto.',
+          ],
+        },
+        {
+          heading: 'Acompanhantes de luxo no Algarve',
+          paragraphs: [
+            'A presença de resorts de luxo, vilas privadas e hotéis de cinco estrelas em toda a região do Algarve cria um contexto para uma procura específica: acompanhantes de luxo no Algarve com disponibilidade para encontros de alto padrão, jantares, eventos e companhia social. Os perfis verificados da Onesugar incluem acompanhantes com experiência neste tipo de encontro, com a discrição que esse contexto exige.',
+          ],
+        },
+        {
+          heading: 'O Algarve e os visitantes internacionais',
+          paragraphs: [
+            'A região recebe visitantes britânicos, alemães, irlandeses e escandinavos em grande número, muitos dos quais procuram escorts no Algarve em inglês. A plataforma tem perfis com disponibilidade para comunicação em diferentes línguas, tornando-a adequada tanto para clientes nacionais como para visitantes internacionais.',
+            'A Onesugar não guarda histórico de contactos nem partilha dados pessoais com terceiros.',
+          ],
+        },
+      ],
+      nearbyLinks: [
+        { city: 'Beja', slug: 'beja' },
+        { city: 'Setúbal', slug: 'setubal' },
+        { city: 'Évora', slug: 'evora' },
+      ],
+    },
+    faq: [
+      {
+        q: 'Como encontrar acompanhantes no Algarve com perfis verificados?',
+        a: 'Na Onesugar, navegue pelos perfis disponíveis em Faro, que cobre toda a região do Algarve. Todos os perfis passaram por verificação. Filtre por disponibilidade e preferência directamente na página.',
+      },
+      {
+        q: 'Há escorts no Algarve disponíveis fora da época de verão?',
+        a: 'Sim. A plataforma tem perfis activos ao longo de todo o ano. A disponibilidade varia por perfil, mas a oferta mantém-se activa fora dos meses de pico.',
+      },
+      {
+        q: 'A Onesugar tem acompanhantes de luxo no Algarve?',
+        a: 'Sim. Os perfis verificados incluem acompanhantes de luxo no Algarve com experiência em encontros sociais, jantares e eventos privados de alto padrão.',
+      },
+      {
+        q: 'As escorts em Faro falam inglês?',
+        a: 'Muitos perfis têm disponibilidade para comunicar em inglês, dada a natureza internacional da região. Confirme as línguas disponíveis na descrição de cada perfil.',
+      },
+      {
+        q: 'É seguro contactar acompanhantes em Faro através da Onesugar?',
+        a: 'A verificação de perfis elimina os riscos mais comuns de portais sem moderação. Os dados dos utilizadores não são partilhados com terceiros e a navegação pode ser feita sem registo.',
+      },
+    ],
   },
+
   viseu: {
     title: 'Acompanhantes em Viseu | Perfis Verificados',
     description:
-      'Encontre acompanhantes em Viseu. Navegue pelos perfis verificados para experiências discretas e privadas na Onesugar.',
+      'Encontre acompanhantes verificadas em Viseu. Perfis reais, discrição total e escorts de luxo na Beira Alta na Onesugar.',
     h1: 'Acompanhantes em Viseu',
-  },
-  leiria: {
-    title: 'Acompanhantes em Leiria | Perfis Verificados',
-    description:
-      'Procura acompanhantes em Leiria? Explore perfis verificados e desfrute de experiências privadas com acompanhantes de confiança na Onesugar.',
-    h1: 'Acompanhantes em Leiria',
-  },
-  setubal: {
-    title: 'Acompanhantes em Setúbal | Perfis Verificados',
-    description:
-      'Explore o catálogo de acompanhantes em Setúbal. Descubra companheiras e desfrute de encontros seguros e discretos na Onesugar.',
-    h1: 'Acompanhantes em Setúbal',
-  },
-  santarem: {
-    title: 'Acompanhantes em Santarém | Perfis Verificados',
-    description:
-      'Descubra acompanhantes em Santarém. Navegue por perfis verificados e agende encontros privados com facilidade na Onesugar.',
-    h1: 'Acompanhantes em Santarém',
-  },
-  braganca: {
-    title: 'Acompanhantes em Bragança | Perfis Verificados',
-    description:
-      'Descubra acompanhantes em Bragança. Navegue pelos perfis verificados e desfrute de encontros privados e discretos na Onesugar.',
-    h1: 'Acompanhantes em Bragança',
-  },
-  madeira: {
-    title: 'Acompanhantes na Madeira | Perfis Verificados',
-    description:
-      'Encontre acompanhantes verificadas na Madeira. Perfis reais, discrição total e encontros privados na ilha da Madeira na Onesugar.',
-    h1: 'Acompanhantes na Madeira',
     intro:
-      'A Madeira é um destino turístico de referência internacional, com uma procura crescente por acompanhantes verificadas na ilha. Para quem procura companhia discreta no Funchal ou em qualquer outro ponto da ilha, a Onesugar disponibiliza perfis verificados com disponibilidade actualizada. Todos os perfis são verificados antes de qualquer publicação. Entre em contacto directamente, sem intermediários.',
+      'Viseu é a capital do distrito homónimo no coração do país, uma cidade que combina uma identidade cultural rica, um centro histórico bem preservado e uma posição geográfica central entre o litoral e o interior. Para quem procura acompanhantes em Viseu com perfis verificados e encontros discretos, a Onesugar disponibiliza companheiras activas na cidade e na região da Beira Alta. A plataforma verifica todos os perfis antes de os publicar. Navegue pelos perfis disponíveis, filtre por preferência e contacte directamente.',
+    editorial: {
+      mainHeading: 'Acompanhantes em Viseu: perfis verificados na Beira Alta',
+      sections: [
+        {
+          paragraphs: [
+            'Viseu é frequentemente referida como uma das cidades portuguesas com melhor qualidade de vida. O seu centro histórico, os museus, a proximidade com a região do Dão e a sua escala humana criam um ambiente que atrai residentes, visitantes e profissionais em deslocação. Essa combinação sustenta uma procura real por acompanhantes em Viseu com disponibilidade para diferentes tipos de encontro.',
+            'Na Onesugar, os perfis disponíveis em Viseu foram verificados antes de qualquer publicação. Fotografia actual, dados reais, disponibilidade confirmada. Para quem procura escorts em Viseu ou acompanhantes de luxo na região da Beira Alta, este nível de verificação distingue a plataforma de portais sem qualquer triagem.',
+          ],
+        },
+        {
+          heading: 'Diversidade de perfis em Viseu',
+          paragraphs: [
+            'A oferta disponível em Viseu na plataforma inclui acompanhantes verificadas para diferentes preferências, incluindo perfis trans com disponibilidade activa na cidade. Seja qual for a preferência, os filtros disponíveis permitem encontrar rapidamente o perfil mais adequado.',
+          ],
+        },
+        {
+          heading: 'Encontros em Viseu: contexto e discrição',
+          paragraphs: [
+            'Viseu tem uma rede hoteleira funcional no centro e nos arredores, com boa relação qualidade-privacidade. A cidade tem uma escala que facilita a discrição, sem a exposição de uma grande metrópole mas com diversidade de oferta real.',
+            'A Onesugar não guarda histórico de contactos nem partilha dados pessoais com terceiros.',
+          ],
+        },
+      ],
+      nearbyLinks: [
+        { city: 'Coimbra', slug: 'coimbra' },
+        { city: 'Guarda', slug: 'guarda' },
+        { city: 'Aveiro', slug: 'aveiro' },
+      ],
+    },
     faq: [
       {
-        q: 'Como encontrar acompanhantes verificadas na Madeira?',
-        a: 'Na Onesugar, navegue pelos perfis disponíveis na Madeira e filtre por tipo de encontro ou preferência. O contacto é feito directamente com a acompanhante, sem intermediários.',
+        q: 'Como encontrar acompanhantes em Viseu com perfis verificados?',
+        a: 'Na Onesugar, navegue pelos perfis disponíveis em Viseu e filtre por disponibilidade ou preferência. O contacto é feito directamente com a acompanhante, sem intermediários.',
       },
       {
-        q: 'Há acompanhantes disponíveis no Funchal?',
-        a: 'Sim. A maioria dos perfis activos na Madeira tem base no Funchal, a capital da ilha. Consulte a disponibilidade de cada perfil directamente na plataforma.',
+        q: 'A Onesugar tem acompanhantes de luxo em Viseu?',
+        a: 'Sim. Os perfis verificados de Viseu incluem acompanhantes de luxo para encontros sociais e privados. Consulte a descrição de cada perfil para ver o tipo de companhia disponível.',
       },
       {
-        q: 'É seguro contactar acompanhantes na Madeira através da Onesugar?',
+        q: 'Há perfis trans disponíveis em Viseu na plataforma?',
+        a: 'Sim. A plataforma tem perfis trans verificados em Viseu com disponibilidade activa. Utilize os filtros disponíveis para encontrar o perfil mais adequado.',
+      },
+      {
+        q: 'É seguro contactar escorts em Viseu através da Onesugar?',
         a: 'A verificação de perfis elimina os riscos mais comuns de portais sem moderação. Os dados pessoais dos utilizadores não são partilhados com terceiros.',
       },
     ],
   },
+
+  leiria: {
+    title: 'Acompanhantes em Leiria | Perfis Verificados',
+    description:
+      'Encontre acompanhantes verificadas em Leiria. Perfis reais, acompanhantes de luxo e escorts verificadas no centro de Portugal na Onesugar.',
+    h1: 'Acompanhantes em Leiria',
+    intro:
+      'Leiria é a capital do distrito homónimo e um dos centros urbanos com crescimento mais consistente do centro de Portugal nos últimos anos. Bem posicionada entre Lisboa e Coimbra, com boa ligação rodoviária e ferroviária, a cidade atrai profissionais, estudantes universitários e visitantes que passam pelo litoral centro. Para quem procura acompanhantes em Leiria com perfis verificados e encontros discretos, a Onesugar disponibiliza companheiras activas na cidade e na região. Todos os perfis são verificados antes de qualquer publicação. Navegue pelos perfis disponíveis e contacte directamente.',
+    editorial: {
+      mainHeading: 'Acompanhantes em Leiria: oferta verificada no centro do país',
+      sections: [
+        {
+          paragraphs: [
+            'A posição geográfica de Leiria torna-a num ponto de passagem natural entre o norte e o sul, entre o litoral e o interior. A cidade é sede de distrito, tem uma universidade activa e recebe um fluxo constante de profissionais e visitantes que se deslocam na região Centro. Esse perfil alimenta uma procura real por acompanhantes em Leiria com disponibilidade para diferentes tipos de encontro.',
+            'Na Onesugar, os perfis disponíveis em Leiria passaram por verificação antes de qualquer publicação. Numa cidade de dimensão intermédia, a ausência de verificação noutros portais é especialmente problemática, com muitos perfis abandonados ou falsos. A Onesugar resolve esse problema à entrada.',
+          ],
+        },
+        {
+          heading: 'Acompanhantes de luxo em Leiria',
+          paragraphs: [
+            'Leiria tem uma das procuras mais expressivas por acompanhantes de luxo entre as cidades de dimensão intermédia em Portugal, o que reflecte um perfil de utilizador com exigências claras em termos de qualidade e discrição. Os perfis verificados da Onesugar em Leiria incluem acompanhantes com experiência em encontros sociais, jantares e momentos privados de alto padrão.',
+          ],
+        },
+        {
+          heading: 'Leiria e a região: diversidade de oferta',
+          paragraphs: [
+            'A plataforma tem em Leiria perfis para diferentes preferências, incluindo acompanhantes trans com disponibilidade activa na cidade e arredores. Os filtros disponíveis permitem encontrar rapidamente o perfil mais adequado.',
+            'A Onesugar não guarda histórico de contactos nem partilha dados pessoais com terceiros. A discrição é garantida de ambos os lados.',
+          ],
+        },
+      ],
+      nearbyLinks: [
+        { city: 'Coimbra', slug: 'coimbra' },
+        { city: 'Santarém', slug: 'santarem' },
+        { city: 'Aveiro', slug: 'aveiro' },
+      ],
+    },
+    faq: [
+      {
+        q: 'Como encontrar acompanhantes em Leiria com perfis verificados?',
+        a: 'Na Onesugar, navegue pelos perfis disponíveis em Leiria e filtre por disponibilidade ou tipo de encontro. O contacto é feito directamente com a acompanhante, sem intermediários.',
+      },
+      {
+        q: 'Há acompanhantes de luxo disponíveis em Leiria?',
+        a: 'Sim. A Onesugar tem perfis de acompanhantes de luxo em Leiria verificados e com disponibilidade actualizada para jantares, eventos e encontros privados.',
+      },
+      {
+        q: 'A Onesugar tem perfis trans em Leiria?',
+        a: 'Sim. A plataforma tem perfis trans verificados em Leiria com disponibilidade activa. Utilize os filtros disponíveis para encontrar o perfil mais adequado.',
+      },
+      {
+        q: 'Há massagens eróticas disponíveis em Leiria na plataforma?',
+        a: 'A Onesugar lista diferentes tipos de perfis, incluindo profissionais de massagem sensorial em Leiria. Consulte a descrição de cada perfil para ver o tipo de serviço disponível.',
+      },
+      {
+        q: 'É seguro contactar acompanhantes em Leiria através da Onesugar?',
+        a: 'A verificação de perfis elimina os riscos mais comuns de portais sem moderação. Os dados pessoais dos utilizadores não são partilhados com terceiros e a navegação pode ser feita sem registo.',
+      },
+    ],
+  },
+
+  setubal: {
+    title: 'Acompanhantes em Setúbal | Perfis Verificados',
+    description:
+      'Encontre acompanhantes verificadas em Setúbal. Perfis reais, discrição total e escorts verificadas na Margem Sul e Península de Setúbal na Onesugar.',
+    h1: 'Acompanhantes em Setúbal',
+    intro:
+      'O distrito de Setúbal é um dos mais populosos do país e engloba a Margem Sul de Lisboa, a Península de Setúbal e a região da Arrábida. Cidades como Almada, Barreiro, Seixal, Palmela e a própria Setúbal fazem parte de um território com uma identidade própria, a poucos minutos da capital por ponte ou ferry. Para quem procura acompanhantes em Setúbal com perfis verificados e encontros discretos, a Onesugar disponibiliza companheiras activas em toda a região. Todos os perfis são verificados antes de qualquer publicação. Navegue pelos perfis disponíveis e contacte directamente.',
+    editorial: {
+      mainHeading: 'Acompanhantes em Setúbal: perfis verificados na Margem Sul e Península de Setúbal',
+      sections: [
+        {
+          paragraphs: [
+            'O distrito de Setúbal é muitas vezes subvalorizado como destino para encontros discretos, mas a sua realidade é diferente. Com uma população de mais de 800 mil habitantes, uma localização privilegiada junto ao estuário do Sado e a presença de zonas residenciais de alta qualidade em toda a Península de Setúbal, a região tem uma procura por acompanhantes verificadas que é consistente ao longo do ano.',
+            'Na Onesugar, os perfis disponíveis em Setúbal cobrem toda a região, desde Almada e Seixal na Margem Sul até Palmela, Sesimbra e Setúbal cidade. Todos os perfis foram verificados antes de serem publicados, com fotografia actual e disponibilidade confirmada.',
+          ],
+        },
+        {
+          heading: 'Setúbal e a proximidade com Lisboa',
+          paragraphs: [
+            'A ligação rápida entre Setúbal e Lisboa, seja pela Ponte 25 de Abril, pela Ponte Vasco da Gama ou pelo ferry do Seixal, torna o distrito especialmente conveniente para quem trabalha ou visita a capital mas prefere a privacidade de um contexto diferente. Muitos utilizadores que procuram escorts na região de Setúbal valorizam exactamente esse distanciamento discreto da capital.',
+            'A Arrábida e as zonas de turismo de natureza nos arredores de Setúbal oferecem também um contexto diferente para encontros que combinam privacidade e ambiente natural. A Onesugar não guarda histórico de contactos nem partilha dados pessoais com terceiros.',
+          ],
+        },
+      ],
+      nearbyLinks: [
+        { city: 'Lisboa', slug: 'lisboa' },
+        { city: 'Évora', slug: 'evora' },
+        { city: 'Beja', slug: 'beja' },
+      ],
+    },
+    faq: [
+      {
+        q: 'Como encontrar acompanhantes em Setúbal com perfis verificados?',
+        a: 'Na Onesugar, navegue pelos perfis disponíveis em Setúbal, que cobre toda a região incluindo Almada, Seixal, Palmela e Setúbal cidade. Filtre por disponibilidade e contacte directamente.',
+      },
+      {
+        q: 'A Onesugar tem acompanhantes de luxo em Setúbal?',
+        a: 'Sim. Os perfis verificados de Setúbal incluem acompanhantes de luxo para jantares, eventos e encontros privados. Consulte a descrição de cada perfil para ver o tipo de companhia disponível.',
+      },
+      {
+        q: 'Posso encontrar acompanhantes em Setúbal perto de Lisboa?',
+        a: 'Sim. O distrito de Setúbal inclui Almada e toda a Margem Sul, a poucos minutos de Lisboa por ponte ou ferry. Muitos perfis têm disponibilidade para encontros em toda a área metropolitana.',
+      },
+      {
+        q: 'É seguro contactar escorts em Setúbal através da Onesugar?',
+        a: 'A verificação de perfis elimina os principais riscos de portais sem moderação. Os dados dos utilizadores não são partilhados com terceiros e a navegação pode ser feita sem registo.',
+      },
+    ],
+  },
+
+  santarem: {
+    title: 'Acompanhantes em Santarém | Perfis Verificados',
+    description:
+      'Encontre acompanhantes verificadas em Santarém. Perfis reais, discrição total e contacto directo no Ribatejo na Onesugar.',
+    h1: 'Acompanhantes em Santarém',
+    intro:
+      'Santarém é a capital do Ribatejo e uma das cidades históricas mais marcantes do centro de Portugal, conhecida pelos seus miradouros sobre o Tejo, pela sua arquitectura medieval e pela tradição equestre que define a identidade da região. Para quem procura acompanhantes em Santarém com perfis verificados e encontros discretos, a Onesugar disponibiliza companheiras activas na cidade e na região do Ribatejo. A plataforma verifica todos os perfis antes de os publicar, garantindo informações reais e actuais. Navegue pelos perfis disponíveis e contacte directamente.',
+    editorial: {
+      mainHeading: 'Acompanhantes em Santarém: perfis verificados no Ribatejo',
+      sections: [
+        {
+          paragraphs: [
+            'Santarém tem uma posição geográfica central que a torna num ponto de referência para quem se desloca entre Lisboa e Coimbra, ou entre o litoral e o interior do país. A cidade tem uma dimensão que combina a tranquilidade do interior com a acessibilidade de uma capital de distrito bem ligada às principais artérias do país.',
+            'Para quem procura acompanhantes em Santarém ou escorts na região do Ribatejo, a Onesugar centraliza a oferta verificada num único ponto. Todos os perfis foram verificados antes de serem publicados, com fotografia actual, disponibilidade confirmada e dados que correspondem ao que encontra na prática.',
+          ],
+        },
+        {
+          heading: 'Santarém: discrição num contexto diferente',
+          paragraphs: [
+            'A escala de Santarém é, para muitos utilizadores, um atributo em termos de discrição. O anonimato é mais fácil de preservar do que numa grande metrópole, e a rede hoteleira local oferece opções adequadas para encontros privados, tanto no centro histórico como nas zonas periféricas da cidade.',
+            'A Onesugar não guarda histórico de contactos nem partilha dados pessoais com terceiros. Todos os encontros ficam exclusivamente entre as partes envolvidas.',
+          ],
+        },
+      ],
+      nearbyLinks: [
+        { city: 'Lisboa', slug: 'lisboa' },
+        { city: 'Leiria', slug: 'leiria' },
+        { city: 'Coimbra', slug: 'coimbra' },
+      ],
+    },
+    faq: [
+      {
+        q: 'Como encontrar acompanhantes em Santarém com perfis verificados?',
+        a: 'Na Onesugar, consulte os perfis disponíveis em Santarém, filtre por disponibilidade ou tipo de encontro e contacte directamente. Não são necessários intermediários.',
+      },
+      {
+        q: 'Há acompanhantes de luxo disponíveis em Santarém?',
+        a: 'Sim. A Onesugar tem perfis de acompanhantes de luxo em Santarém verificados e com disponibilidade actualizada. Consulte a descrição de cada perfil para ver o tipo de companhia disponível.',
+      },
+      {
+        q: 'Os perfis de acompanhantes em Santarém são reais?',
+        a: 'Sim. Todos os perfis publicados na Onesugar passam por verificação de identidade e disponibilidade antes de serem publicados.',
+      },
+      {
+        q: 'É seguro contactar acompanhantes em Santarém pela Onesugar?',
+        a: 'A verificação de perfis elimina os riscos mais comuns de portais sem moderação. Os dados dos utilizadores não são partilhados com terceiros e a plataforma não guarda histórico de contactos.',
+      },
+    ],
+  },
+
+  braganca: {
+    title: 'Acompanhantes em Bragança | Perfis Verificados',
+    description:
+      'Encontre acompanhantes verificadas em Bragança. Perfis reais, discrição total e contacto directo em Trás-os-Montes na Onesugar.',
+    h1: 'Acompanhantes em Bragança',
+    intro:
+      'Bragança é a capital do distrito mais a nordeste de Portugal, conhecida pelo seu castelo medieval, pela Terra Fria transmontana e pela proximidade com Espanha. A cidade tem uma identidade rural e histórica muito própria, num contexto de baixa densidade urbana que oferece privacidade natural. Para quem procura acompanhantes em Bragança com perfis verificados, a Onesugar disponibiliza companheiras activas na cidade e na região de Trás-os-Montes. Todos os perfis são verificados antes de qualquer publicação. Navegue abaixo e contacte directamente.',
+    editorial: {
+      mainHeading: 'Acompanhantes em Bragança: perfis verificados no nordeste de Portugal',
+      sections: [
+        {
+          paragraphs: [
+            'Bragança é uma das capitais de distrito mais remotas do país, encostada à fronteira com Espanha e rodeada pelo Parque Natural de Montesinho. Essa condição geográfica confere à cidade uma identidade única: baixa densidade urbana, privacidade natural elevada e um ritmo de vida tranquilo que valoriza a discrição por defeito.',
+            'Para quem procura acompanhantes em Bragança, a principal dificuldade nos portais tradicionais é a escassez de perfis activos com informação fiável. Na Onesugar, os perfis disponíveis foram verificados antes de qualquer publicação, garantindo que as informações são reais e a disponibilidade é confirmada.',
+          ],
+        },
+        {
+          heading: 'Bragança e a fronteira com Espanha',
+          paragraphs: [
+            'A proximidade com Zamora e com a região da Galiza torna Bragança também um ponto de chegada para visitantes que entram pelo lado espanhol, contribuindo para uma procura que não é exclusivamente local. Para quem visita a cidade em trânsito ou em estadia, a plataforma tem perfis com disponibilidade para encontros no próprio dia.',
+            'A Onesugar não guarda histórico de contactos nem partilha dados pessoais com terceiros. A privacidade é garantida de ambos os lados.',
+          ],
+        },
+      ],
+      nearbyLinks: [
+        { city: 'Vila Real', slug: 'vila-real' },
+        { city: 'Porto', slug: 'porto' },
+      ],
+    },
+    faq: [
+      {
+        q: 'Como encontrar acompanhantes em Bragança com perfis verificados?',
+        a: 'Na Onesugar, navegue pelos perfis disponíveis em Bragança, filtre por disponibilidade ou preferência e contacte directamente com a acompanhante.',
+      },
+      {
+        q: 'Os perfis de acompanhantes em Bragança são reais?',
+        a: 'Sim. Todos os perfis publicados na Onesugar passam por verificação de identidade e disponibilidade antes de serem publicados. O selo verificado confirma que os dados foram validados.',
+      },
+      {
+        q: 'Há escorts disponíveis em Bragança com disponibilidade imediata?',
+        a: 'Alguns perfis indicam disponibilidade imediata. Consulte a disponibilidade actualizada directamente na página de cada acompanhante.',
+      },
+      {
+        q: 'É seguro contactar acompanhantes em Bragança pela Onesugar?',
+        a: 'A verificação de perfis elimina os riscos mais comuns de portais sem moderação. Os dados dos utilizadores não são partilhados com terceiros e a plataforma não guarda histórico de contactos.',
+      },
+    ],
+  },
+
+  // ── Região Autónoma ────────────────────────────────────────────────────────
+
+  madeira: {
+    title: 'Acompanhantes na Madeira | Perfis Verificados',
+    description:
+      'Encontre acompanhantes verificadas na Madeira. Perfis reais, discrição total e escorts de luxo na ilha mais visitada do Atlântico na Onesugar.',
+    h1: 'Acompanhantes na Madeira',
+    intro:
+      'A Madeira é um dos destinos turísticos mais procurados do mundo, conhecida pelo seu clima ameno durante todo o ano, pelas levadas, pelos picos e pela hospitalidade particular da sua gente. Para quem procura acompanhantes na Madeira com perfis verificados e encontros discretos, a Onesugar disponibiliza uma selecção de companheiras com presença activa na ilha. O Funchal, como capital e maior centro urbano, concentra a maioria dos perfis activos, com disponibilidade para encontros na cidade e em toda a ilha. Todos os perfis são verificados antes de qualquer publicação. Navegue pelos perfis disponíveis, filtre por preferência e entre em contacto directamente, sem intermediários.',
+    editorial: {
+      mainHeading: 'Acompanhantes na Madeira: perfis verificados na pérola do Atlântico',
+      sections: [
+        {
+          paragraphs: [
+            'A Madeira recebe anualmente mais de um milhão de visitantes, um número expressivo para uma ilha com cerca de 250 mil habitantes. Esse fluxo constante de turistas nacionais e internacionais, combinado com uma comunidade residente activa e uma vida nocturna centrada no Funchal, cria uma procura real e diversificada por acompanhantes na Madeira ao longo de todo o ano.',
+            'Na Onesugar, os perfis disponíveis para a Madeira foram verificados individualmente antes de serem publicados. Fotografia actual, disponibilidade confirmada e dados que correspondem ao que encontra na prática. Numa ilha onde a oferta verificada é ainda mais escassa do que no continente, esta diferença tem um impacto directo na qualidade da experiência.',
+          ],
+        },
+        {
+          heading: 'O Funchal e a procura por escorts verificadas',
+          paragraphs: [
+            'O Funchal concentra a maior parte da actividade turística e urbana da ilha. Os hotéis de cinco estrelas da zona hoteleira, os restaurantes da Zona Velha e o ambiente cosmopolita do centro da cidade criam um contexto adequado para encontros discretos de qualidade. Para quem procura acompanhantes de luxo no Funchal para um jantar, evento social ou encontro privado, os perfis verificados da Onesugar indicam claramente o tipo de companhia disponível e os contactos preferidos.',
+            'A ilha tem também zonas mais tranquilas fora do Funchal, como Câmara de Lobos, Machico e a costa norte, onde a privacidade é naturalmente mais elevada. Muitos perfis activos na plataforma têm disponibilidade para se deslocar a diferentes pontos da ilha.',
+          ],
+        },
+        {
+          heading: 'A Madeira e os visitantes internacionais',
+          paragraphs: [
+            'A ilha recebe um número significativo de visitantes britânicos, alemães, escandinavos e do mercado português continental, muitos dos quais procuram escorts na Madeira com disponibilidade para comunicar em inglês. Os perfis da Onesugar para a Madeira incluem acompanhantes com diferentes competências linguísticas, tornando a plataforma adequada tanto para clientes locais como para quem chega de fora.',
+            'A Onesugar não guarda histórico de contactos entre utilizadores e acompanhantes, nem partilha qualquer dado com terceiros. A discrição é garantida de ambos os lados.',
+          ],
+        },
+      ],
+      nearbyLinks: [
+        { city: 'Lisboa', slug: 'lisboa' },
+        { city: 'Porto', slug: 'porto' },
+        { city: 'Faro', slug: 'faro' },
+      ],
+    },
+    faq: [
+      {
+        q: 'Como encontrar acompanhantes verificadas na Madeira?',
+        a: 'Na Onesugar, navegue pelos perfis disponíveis para a Madeira e filtre por tipo de encontro, disponibilidade ou preferência. O contacto é feito directamente com a acompanhante, sem intermediários.',
+      },
+      {
+        q: 'Há acompanhantes disponíveis no Funchal?',
+        a: 'Sim. A maioria dos perfis activos na Madeira tem base no Funchal, a capital da ilha. Consulte a disponibilidade de cada perfil directamente na página para confirmar a zona de actuação.',
+      },
+      {
+        q: 'A Onesugar tem acompanhantes de luxo na Madeira?',
+        a: 'Sim. Os perfis verificados para a Madeira incluem acompanhantes de luxo com experiência em encontros sociais, jantares e eventos privados. A descrição de cada perfil especifica o tipo de companhia disponível.',
+      },
+      {
+        q: 'Há escorts na Madeira que falam inglês?',
+        a: 'Sim. Dada a natureza internacional do turismo na ilha, vários perfis têm disponibilidade para comunicar em inglês e outras línguas. Confirme as línguas disponíveis na descrição de cada perfil.',
+      },
+      {
+        q: 'É seguro contactar acompanhantes na Madeira através da Onesugar?',
+        a: 'A verificação de perfis elimina os riscos mais comuns de portais sem moderação. Os dados pessoais dos utilizadores não são partilhados com terceiros e a navegação pode ser feita sem registo.',
+      },
+      {
+        q: 'Os perfis de acompanhantes na Madeira são reais?',
+        a: 'Sim. Todos os perfis publicados na Onesugar passam por verificação de identidade e disponibilidade antes de serem publicados. O selo verificado confirma que os dados foram validados pela plataforma.',
+      },
+    ],
+  },
 };
+
+// ── Static params ─────────────────────────────────────────────────────────────
+// Pré-renderiza estaticamente todas as páginas de cidade conhecidas em build
+// time. O HTML entregue pelo servidor já contém title, description, robots e
+// canonical no <head> desde o primeiro byte, sem depender do RSC streaming.
+// Páginas com slugs fora desta lista são renderizadas on-demand (fallback SSR).
+
+export function generateStaticParams() {
+  return Object.keys(cityMetadata).map((city) => ({ city }));
+}
 
 // ── Metadata ──────────────────────────────────────────────────────────────────
 
@@ -798,7 +1124,8 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { city } = await params;
   const cityKey = city.toLowerCase();
-  const capitalizedCity = formatCitySlug(city);
+  const capitalizedCity =
+    city.charAt(0).toUpperCase() + city.slice(1).replaceAll('-', ' ');
 
   const current = cityMetadata[cityKey] ?? {
     title: `Acompanhantes em ${capitalizedCity} | Perfis Verificados`,
@@ -809,8 +1136,15 @@ export async function generateMetadata({
   return {
     title: current.title,
     description: current.description,
-    alternates: {
-      canonical: `https://www.onesugar.pt/location/${cityKey}`,
+    robots: {
+      index: true,
+      follow: true,
+      googleBot: {
+        index: true,
+        follow: true,
+        'max-image-preview': 'large',
+        'max-snippet': -1,
+      },
     },
     openGraph: {
       title: current.title,
@@ -827,7 +1161,8 @@ export async function generateMetadata({
 
 function LocationH1({ citySlug }: { citySlug: string }) {
   const cityKey = citySlug.toLowerCase();
-  const capitalizedCity = formatCitySlug(citySlug);
+  const capitalizedCity =
+    citySlug.charAt(0).toUpperCase() + citySlug.slice(1).replaceAll('-', ' ');
   const h1Text =
     cityMetadata[cityKey]?.h1 ?? `Acompanhantes em ${capitalizedCity}`;
   return <h1 className="text-3xl font-bold mb-6">{h1Text}</h1>;
@@ -839,35 +1174,6 @@ function CityIntro({ citySlug }: { citySlug: string }) {
   return (
     <p className="mb-8 text-sm text-muted-foreground leading-relaxed max-w-3xl">
       {data.intro}
-    </p>
-  );
-}
-
-function NearbyLinks({ links }: { links: NearbyLink[] }) {
-  if (links.length === 0) return null;
-  return (
-    <p className="text-sm text-muted-foreground leading-relaxed mt-4">
-      Se está a explorar outras opções em Portugal, encontra também perfis
-      activos em{' '}
-      {links.map((link, idx) => {
-        const separator =
-          idx < links.length - 2
-            ? ', '
-            : idx === links.length - 2
-            ? ' e '
-            : '.';
-        return (
-          <span key={link.slug}>
-            <Link
-              href={`/location/${link.slug}`}
-              className="text-rose-500 hover:underline"
-            >
-              {link.city}
-            </Link>
-            {separator}
-          </span>
-        );
-      })}
     </p>
   );
 }
@@ -892,7 +1198,7 @@ function CityEditorialAndFAQ({ citySlug }: { citySlug: string }) {
     : null;
 
   return (
-    <section className="mt-10 mb-6">
+    <div className="mt-10 mb-6">
       {data.editorial && (
         <div className="mb-10">
           <h2 className="text-xl font-bold mb-5">
@@ -915,7 +1221,27 @@ function CityEditorialAndFAQ({ citySlug }: { citySlug: string }) {
               ))}
             </div>
           ))}
-          <NearbyLinks links={data.editorial.nearbyLinks} />
+          {data.editorial.nearbyLinks.length > 0 && (
+            <p className="text-sm text-muted-foreground leading-relaxed mt-4">
+              Se está a explorar outras opções em Portugal, encontra também
+              perfis activos em{' '}
+              {data.editorial.nearbyLinks.map((link, idx) => (
+                <span key={link.slug}>
+                  <Link
+                    href={`/location/${link.slug}`}
+                    className="text-rose-500 hover:underline"
+                  >
+                    {link.city}
+                  </Link>
+                  {idx < data.editorial!.nearbyLinks.length - 2
+                    ? ', '
+                    : idx === data.editorial!.nearbyLinks.length - 2
+                    ? ' e '
+                    : '.'}
+                </span>
+              ))}
+            </p>
+          )}
         </div>
       )}
       {data.faq && data.faq.length > 0 && (
@@ -933,7 +1259,6 @@ function CityEditorialAndFAQ({ citySlug }: { citySlug: string }) {
               </div>
             ))}
           </div>
-
           {faqSchema && (
             <script
               type="application/ld+json"
@@ -942,28 +1267,32 @@ function CityEditorialAndFAQ({ citySlug }: { citySlug: string }) {
           )}
         </div>
       )}
-    </section>
+    </div>
   );
 }
 
 // ── CTA helpers ───────────────────────────────────────────────────────────────
 
-function getCityName(citySlug: string): string {
+// Retorna a preposição + nome da cidade exactamente como aparece no H1,
+// sem o prefixo "Acompanhantes". Ex.: "na Madeira", "no Porto", "em Lisboa".
+// Usado nos CTAs para evitar "em Madeira" ou "em Guarda" gramaticalmente errados.
+function getCityLabel(citySlug: string): string {
   const data = cityMetadata[citySlug.toLowerCase()];
   if (data?.h1) {
-    // Remove o prefixo "Acompanhantes em/no/na/nos " do H1 para obter o nome.
-    return data.h1.replace(/^Acompanhantes\s+(?:em|no|na|nos)\s+/i, '').trim();
+    return data.h1.replace(/^Acompanhantes\s+/i, '').trim();
   }
-  return formatCitySlug(citySlug);
+  return (
+    citySlug.charAt(0).toUpperCase() + citySlug.slice(1).replaceAll('-', ' ')
+  );
 }
 
 // CTA Posicao 1 - entre os perfis e o bloco editorial
 function RegistrationCTAInline({ citySlug }: { citySlug: string }) {
-  const city = getCityName(citySlug);
+  const cityLabel = getCityLabel(citySlug);
   return (
     <div className="my-10 rounded-2xl border-2 border-dashed border-rose-300 bg-rose-50/10 dark:bg-rose-950/20 dark:border-rose-900/60 px-6 py-5">
       <p className="font-semibold text-sm mb-1">
-        Trabalhas como acompanhante em {city}?
+        Trabalhas como acompanhante {cityLabel}?
       </p>
       <p className="text-xs text-muted-foreground mb-4">
         Regista o teu perfil e aparece para milhares de utilizadores
@@ -989,11 +1318,11 @@ function RegistrationCTAInline({ citySlug }: { citySlug: string }) {
 
 // CTA Posicao 2 - apos o FAQ, antes da paginacao
 function RegistrationCTABottom({ citySlug }: { citySlug: string }) {
-  const city = getCityName(citySlug);
+  const cityLabel = getCityLabel(citySlug);
   return (
     <div className="my-10 rounded-2xl border-2 border-dashed border-rose-500 bg-rose-50/10 dark:bg-rose-950/20 px-6 py-7 text-center">
       <p className="font-semibold mb-1">
-        Queres anunciar em {city}? Junta-te à Onesugar.
+        Queres anunciar {cityLabel}? Junta-te à Onesugar.
       </p>
       <p className="text-sm text-muted-foreground mb-5">
         Perfil verificado, visibilidade imediata, planos a partir de €0.
@@ -1031,8 +1360,7 @@ export default async function CompanionsPage({
   searchParams: Promise<FilterTypesCompanions>;
 }) {
   const [{ city }, sParams] = await Promise.all([params, searchParams]);
-  const parsedPage = Number.parseInt(sParams.page ?? '1', 10);
-  const page = Number.isFinite(parsedPage) && parsedPage > 0 ? parsedPage : 1;
+  const page = parseInt(sParams.page ?? '1', 10);
 
   return (
     <div className="container mx-auto px-10 py-8">
@@ -1053,7 +1381,7 @@ export default async function CompanionsPage({
         </Link>
       </div>
 
-      {/* POSICAO 1: Intro paragraph - acima do carrossel */}
+      {/* Posicao 1: Intro - acima do carrossel */}
       <CityIntro citySlug={city} />
 
       <div className="mb-8">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -220,10 +220,10 @@ export default async function HomePage() {
 
               {/* LEFT: text */}
               <div className="space-y-6">
-                {/* "Sugar do dia" badge — visual label only, not a heading */}
+                {/* "Exclusiva Onesugar" badge — visual label only, not a heading */}
                 <span className="inline-flex items-center gap-1.5 bg-rose-600/20 border border-rose-500/40 text-rose-300 text-sm font-medium px-3 py-1 rounded-full">
                   <Star className="h-3.5 w-3.5 fill-rose-400 text-rose-400" />
-                  Sugar do dia
+                  Exclusiva Onesugar
                 </span>
                 <h1
                   id="hero-heading"
@@ -286,7 +286,7 @@ export default async function HomePage() {
                     <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-rose-400/60 to-transparent z-10" />
                     <Image
                       src={doDia?.imageUrl ?? '/banner-square.jpeg'}
-                      alt={doDia ? `${doDia.name} — Sugar do dia` : 'Curadoria Cris Galera — Embaixadora de Qualidade'}
+                      alt={doDia ? `${doDia.name} — Exclusiva Onesugar` : 'Curadoria Cris Galera — Embaixadora de Qualidade'}
                       fill
                       className="object-cover object-center transition-transform duration-300 group-hover:scale-105"
                       priority
@@ -318,7 +318,7 @@ export default async function HomePage() {
                   <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-rose-400/60 to-transparent z-10" />
                   <Image
                     src={doDia?.imageUrl ?? '/onesugar-mobile.jpeg'}
-                    alt={doDia ? `${doDia.name} — Sugar do dia` : 'Bem vindo a Onesugar'}
+                    alt={doDia ? `${doDia.name} — Exclusiva Onesugar` : 'Bem vindo a Onesugar'}
                     fill
                     className="object-cover object-center transition-transform duration-300 group-hover:scale-105"
                     priority
@@ -329,10 +329,10 @@ export default async function HomePage() {
 
               {/* Text + CTA */}
               <div className="relative z-10 w-full space-y-4 text-center">
-                {/* "Sugar do dia" badge */}
+                {/* "Exclusiva Onesugar" badge */}
                 <span className="inline-flex items-center gap-1.5 bg-rose-600/20 border border-rose-500/40 text-rose-300 text-xs font-medium px-3 py-1 rounded-full mx-auto">
                   <Star className="h-3 w-3 fill-rose-400 text-rose-400" />
-                  Sugar do dia
+                  Exclusiva Onesugar
                 </span>
                 <h1
                   id="hero-heading-mobile"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -19,6 +19,7 @@ import { SectionHeading } from '@/components/v0/section-heading';
 import { CitySelectionModal } from '@/components/city-selection-modal';
 import { HeroCarouselWrapper } from '@/components/hero-carousel-wrapper';
 import { LiteYouTube } from '@/components/lite-youtube';
+import { getDoDiaCompanion } from '@/db/queries/companions';
 import { PlanType } from '@/db/queries/kv';
 import { kv } from '@/db/index';
 
@@ -194,7 +195,7 @@ export const metadata: Metadata = {
 export default async function HomePage() {
   kv.ping().catch(() => null);
 
-  const h1Text = 'Acompanhantes Premium em Portugal';
+  const doDia = await getDoDiaCompanion();
 
   return (
     <div className="flex min-h-screen flex-col">
@@ -223,30 +224,45 @@ export default async function HomePage() {
                   id="hero-heading"
                   className="text-3xl md:text-4xl lg:text-5xl xl:text-6xl font-bold tracking-tighter text-white"
                 >
-                  {h1Text}
+                  Sugar do dia
                 </h1>
-                <h2 className="text-base md:text-lg text-white/70 max-w-md">
-                  Descubra as acompanhantes mais sofisticadas de Portugal com total discrição e segurança.
-                </h2>
-                <Image
-                  src="/badge-onesugar.png"
-                  alt="Bem vindo a Onesugar"
-                  width={400}
-                  height={300}
-                  priority
-                />
+                {doDia ? (
+                  <div className="space-y-5">
+                    <div className="flex items-center gap-3">
+                      <span className="text-3xl lg:text-4xl xl:text-5xl font-bold text-white">{doDia.name}</span>
+                      {doDia.verified && <ShieldCheck className="h-8 w-8 text-rose-400 shrink-0" />}
+                    </div>
+                    <div className="flex flex-wrap items-center gap-x-5 gap-y-2 text-white/80 text-xl lg:text-2xl font-medium">
+                      <span>{doDia.age} anos</span>
+                      <span className="text-white/30">·</span>
+                      <span className="flex items-center gap-2"><MapPin className="h-5 w-5" />{doDia.city}</span>
+                      <span className="text-white/30">·</span>
+                      <span className="text-rose-300 font-semibold">€{doDia.price}/hora</span>
+                    </div>
+                    {doDia.shortDescription && (
+                      <p className="text-white/60 text-lg lg:text-xl max-w-sm leading-relaxed">{doDia.shortDescription}</p>
+                    )}
+                    <Link href={`/companions/${doDia.id}`} className="inline-flex items-center gap-2 bg-rose-600 hover:bg-rose-500 text-white text-base lg:text-lg font-semibold px-7 py-3.5 rounded-md transition-colors">
+                      Ver perfil
+                    </Link>
+                  </div>
+                ) : (
+                  <h2 className="text-base md:text-lg text-white/70 max-w-md">
+                    Descubra as acompanhantes mais sofisticadas de Portugal com total discrição e segurança.
+                  </h2>
+                )}
                 <Suspense
                   fallback={
-                    <Button disabled variant="outline" className="gap-2">
-                      <MapPin className="h-4 w-4" />
+                    <Button disabled variant="outline" className="gap-2 text-base py-6 px-7">
+                      <MapPin className="h-5 w-5" />
                       Carregando distritos...
                     </Button>
                   }
                 >
                   <CitySelectionModal
                     triggerButton={
-                      <Button variant="default" className="gap-2 py-5 px-6">
-                        <MapPin className="h-4 w-4" />
+                      <Button variant="default" className="gap-2 py-6 px-7 text-base">
+                        <MapPin className="h-5 w-5" />
                         Encontrar por distrito
                       </Button>
                     }
@@ -254,29 +270,25 @@ export default async function HomePage() {
                 </Suspense>
               </div>
 
-              {/* RIGHT: badge as squircle with glow */}
-              <div className="flex items-center justify-center">
-                {/* Outer glow ring */}
-                <div className="relative">
-                  {/* Blurred rose glow behind the card */}
+              {/* RIGHT: companion photo as square card with glow */}
+              <div className="flex items-center justify-center w-full">
+                <div className="relative w-full max-w-sm lg:max-w-xl xl:max-w-2xl">
                   <div className="absolute -inset-4 rounded-[2.5rem] bg-rose-600/30 blur-2xl" />
-                  {/* Softer wider ambient glow */}
                   <div className="absolute -inset-8 rounded-[3rem] bg-rose-900/20 blur-3xl" />
-                  {/* The badge card itself */}
-                  <div className="relative rounded-[1rem] overflow-hidden ring-1 ring-rose-500/40 shadow-[0_0_40px_-4px_rgba(244,63,94,0.5)]">
-                    {/* Subtle inner top-edge highlight */}
-                    <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-rose-400/60 to-transparent" />
+                  <Link
+                    href={doDia ? `/companions/${doDia.id}` : '#'}
+                    className="block relative rounded-[1rem] overflow-hidden ring-1 ring-rose-500/40 shadow-[0_0_40px_-4px_rgba(244,63,94,0.5)] aspect-square w-full group"
+                  >
+                    <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-rose-400/60 to-transparent z-10" />
                     <Image
-                      src="/banner-square.jpeg"
-                      alt="Curadoria Cris Galera — Embaixadora de Qualidade"
-                      width={1400}
-                      height={900}
-                      className="w-full max-w-sm lg:max-w-3xl object-cover"
+                      src={doDia?.imageUrl ?? '/banner-square.jpeg'}
+                      alt={doDia ? `${doDia.name} — Sugar do dia` : 'Curadoria Cris Galera — Embaixadora de Qualidade'}
+                      fill
+                      className="object-cover object-center transition-transform duration-300 group-hover:scale-105"
                       priority
                     />
-                    {/* Subtle inner bottom-edge shadow */}
-                    <div className="absolute inset-x-0 bottom-0 h-8 bg-gradient-to-t from-black/40 to-transparent" />
-                  </div>
+                    <div className="absolute inset-x-0 bottom-0 h-8 bg-gradient-to-t from-black/40 to-transparent z-10" />
+                  </Link>
                 </div>
               </div>
 
@@ -291,25 +303,24 @@ export default async function HomePage() {
               <div className="absolute inset-0 bg-gradient-to-b from-black/60 via-transparent to-black/50 pointer-events-none" />
               <div className="absolute top-0 right-0 w-2/3 h-2/3 bg-[radial-gradient(ellipse_at_70%_30%,_#f43f5e22_0%,_transparent_70%)] pointer-events-none" />
 
-              {/* Badge squircle */}
+              {/* Companion photo — square, clickable */}
               <div className="relative z-10 w-full max-w-xs">
-                {/* Blurred rose glow */}
                 <div className="absolute -inset-4 rounded-[2.5rem] bg-rose-600/30 blur-2xl" />
-                {/* Wide ambient glow */}
                 <div className="absolute -inset-8 rounded-[3rem] bg-rose-900/20 blur-3xl" />
-                {/* Card */}
-                <div className="relative rounded-[2rem] overflow-hidden ring-1 ring-rose-500/40 shadow-[0_0_40px_-4px_rgba(244,63,94,0.5)]">
-                  <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-rose-400/60 to-transparent" />
+                <Link
+                  href={doDia ? `/companions/${doDia.id}` : '#'}
+                  className="block relative rounded-[2rem] overflow-hidden ring-1 ring-rose-500/40 shadow-[0_0_40px_-4px_rgba(244,63,94,0.5)] aspect-square group"
+                >
+                  <div className="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-rose-400/60 to-transparent z-10" />
                   <Image
-                    src="/onesugar-mobile.jpeg"
-                    alt="Bem vindo a Onesugar"
-                    width={830}
-                    height={1472}
-                    className="w-full h-auto object-cover"
+                    src={doDia?.imageUrl ?? '/onesugar-mobile.jpeg'}
+                    alt={doDia ? `${doDia.name} — Sugar do dia` : 'Bem vindo a Onesugar'}
+                    fill
+                    className="object-cover object-center transition-transform duration-300 group-hover:scale-105"
                     priority
                   />
-                  <div className="absolute inset-x-0 bottom-0 h-8 bg-gradient-to-t from-black/40 to-transparent" />
-                </div>
+                  <div className="absolute inset-x-0 bottom-0 h-8 bg-gradient-to-t from-black/40 to-transparent z-10" />
+                </Link>
               </div>
 
               {/* Text + CTA */}
@@ -318,19 +329,33 @@ export default async function HomePage() {
                   id="hero-heading-mobile"
                   className="text-2xl sm:text-3xl font-bold tracking-tighter text-white"
                 >
-                  {h1Text}
+                  Sugar do dia
                 </h1>
-                <h2 className="text-sm sm:text-base text-white/70">
-                  Descubra as acompanhantes mais sofisticadas de Portugal com total discrição e segurança.
-                </h2>
-                <Image
-                  src="/badge-onesugar.png"
-                  alt="Bem vindo a Onesugar"
-                  width={400}
-                  height={300}
-                  className="w-full h-auto object-cover mix-blend-screen"
-                  priority
-                />
+                {doDia ? (
+                  <div className="space-y-3">
+                    <div className="flex items-center justify-center gap-2">
+                      <span className="text-xl font-bold text-white">{doDia.name}</span>
+                      {doDia.verified && <ShieldCheck className="h-5 w-5 text-rose-400 shrink-0" />}
+                    </div>
+                    <div className="flex items-center justify-center flex-wrap gap-x-3 gap-y-1 text-white/80 text-sm font-medium">
+                      <span>{doDia.age} anos</span>
+                      <span className="text-white/30">·</span>
+                      <span>{doDia.city}</span>
+                      <span className="text-white/30">·</span>
+                      <span className="text-rose-300 font-semibold">€{doDia.price}/hora</span>
+                    </div>
+                    {doDia.shortDescription && (
+                      <p className="text-white/60 text-sm">{doDia.shortDescription}</p>
+                    )}
+                    <Link href={`/companions/${doDia.id}`} className="inline-flex items-center gap-2 bg-rose-600 hover:bg-rose-500 text-white text-sm font-semibold px-4 py-2 rounded-md transition-colors mx-auto">
+                      Ver perfil
+                    </Link>
+                  </div>
+                ) : (
+                  <h2 className="text-sm sm:text-base text-white/70">
+                    Descubra as acompanhantes mais sofisticadas de Portugal com total discrição e segurança.
+                  </h2>
+                )}
                 <Suspense
                   fallback={
                     <Button disabled variant="outline" className="gap-2 w-full">

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -220,13 +220,21 @@ export default async function HomePage() {
 
               {/* LEFT: text */}
               <div className="space-y-6">
+                {/* "Sugar do dia" badge — visual label only, not a heading */}
+                <span className="inline-flex items-center gap-1.5 bg-rose-600/20 border border-rose-500/40 text-rose-300 text-sm font-medium px-3 py-1 rounded-full">
+                  <Star className="h-3.5 w-3.5 fill-rose-400 text-rose-400" />
+                  Sugar do dia
+                </span>
                 <h1
                   id="hero-heading"
                   className="text-3xl md:text-4xl lg:text-5xl xl:text-6xl font-bold tracking-tighter text-white"
                 >
-                  Sugar do dia
+                  Acompanhantes Premium em Portugal
                 </h1>
-                {doDia ? (
+                <h2 className="text-base md:text-lg text-white/70 max-w-md">
+                  Descubra as acompanhantes mais sofisticadas de Portugal com total discrição e segurança.
+                </h2>
+                {doDia && (
                   <div className="space-y-5">
                     <div className="flex items-center gap-3">
                       <span className="text-3xl lg:text-4xl xl:text-5xl font-bold text-white">{doDia.name}</span>
@@ -246,10 +254,6 @@ export default async function HomePage() {
                       Ver perfil
                     </Link>
                   </div>
-                ) : (
-                  <h2 className="text-base md:text-lg text-white/70 max-w-md">
-                    Descubra as acompanhantes mais sofisticadas de Portugal com total discrição e segurança.
-                  </h2>
                 )}
                 <Suspense
                   fallback={
@@ -325,13 +329,21 @@ export default async function HomePage() {
 
               {/* Text + CTA */}
               <div className="relative z-10 w-full space-y-4 text-center">
+                {/* "Sugar do dia" badge */}
+                <span className="inline-flex items-center gap-1.5 bg-rose-600/20 border border-rose-500/40 text-rose-300 text-xs font-medium px-3 py-1 rounded-full mx-auto">
+                  <Star className="h-3 w-3 fill-rose-400 text-rose-400" />
+                  Sugar do dia
+                </span>
                 <h1
                   id="hero-heading-mobile"
                   className="text-2xl sm:text-3xl font-bold tracking-tighter text-white"
                 >
-                  Sugar do dia
+                  Acompanhantes Premium em Portugal
                 </h1>
-                {doDia ? (
+                <h2 className="text-sm sm:text-base text-white/70">
+                  Descubra as acompanhantes mais sofisticadas de Portugal com total discrição e segurança.
+                </h2>
+                {doDia && (
                   <div className="space-y-3">
                     <div className="flex items-center justify-center gap-2">
                       <span className="text-xl font-bold text-white">{doDia.name}</span>
@@ -351,10 +363,6 @@ export default async function HomePage() {
                       Ver perfil
                     </Link>
                   </div>
-                ) : (
-                  <h2 className="text-sm sm:text-base text-white/70">
-                    Descubra as acompanhantes mais sofisticadas de Portugal com total discrição e segurança.
-                  </h2>
                 )}
                 <Suspense
                   fallback={

--- a/components/documentVerificationForm.tsx
+++ b/components/documentVerificationForm.tsx
@@ -238,8 +238,7 @@ export function DocumentVerificationForm({
       if (result.success) {
         toast({
           title: "Vídeo enviado",
-          description:
-            "Seu vídeo foi enviado com sucesso e está aguardando revisão.",
+          description: "Seu vídeo foi enviado com sucesso e está aguardando revisão.",
           variant: "success",
         });
 
@@ -302,9 +301,9 @@ export function DocumentVerificationForm({
 
       if (result.success) {
         toast({
-          title: "Documento enviado",
+          title: "Perfil criado com sucesso!",
           description:
-            "Seu documento foi enviado com sucesso e está aguardando revisão.",
+            "Os seus documentos foram enviados e o perfil está a ser verificado pela nossa equipa.",
           variant: "success",
         });
 

--- a/components/formCompanionRegister.tsx
+++ b/components/formCompanionRegister.tsx
@@ -301,11 +301,6 @@ export function RegisterCompanionForm({
           const companion = await registerCompanionAction(formData);
           currentCompanionId = companion.id;
           setCompanionId(companion.id);
-          toast({
-            variant: "success",
-            title: "Perfil criado",
-            description: `Hey ${formData.name}! Agora fazendo upload das suas fotos.`,
-          });
         } catch (error) {
           toast({
             variant: "destructive",
@@ -457,12 +452,6 @@ export function RegisterCompanionForm({
 
       // Companion already created during photo upload, just redirect
       await completeFirstStepRegistration();
-      toast({
-        variant: "success",
-        title: "Perfil criado com sucesso",
-        description:
-          "Agora envie os documentos de verificação para ativar o seu perfil.",
-      });
       router.push("/companions/verification");
       return;
     }

--- a/components/whatsapp-button.tsx
+++ b/components/whatsapp-button.tsx
@@ -23,7 +23,7 @@ export const WhatsAppButton = ({
       className="fixed bottom-6 right-6 bg-green-500 hover:bg-green-600 text-white rounded-full p-4 shadow-lg transition-all duration-300 ease-in-out z-50 flex items-center justify-center"
     >
       <IconBrandWhatsapp />
-      <span className="ml-2">Contato</span>
+      <span className="ml-2">Contacto</span>
     </Link>
   );
 };

--- a/db/queries/companions.ts
+++ b/db/queries/companions.ts
@@ -256,6 +256,38 @@ function buildCompanionsQuery(
     );
 }
 
+export async function getDoDiaCompanion() {
+  const results = await db
+    .select({
+      id: companionsTable.id,
+      name: companionsTable.name,
+      age: companionsTable.age,
+      price: companionsTable.price,
+      shortDescription: companionsTable.shortDescription,
+      verified: companionsTable.verified,
+      city: citiesTable.city,
+      imageUrl: imagesTable.public_url,
+    })
+    .from(companionsTable)
+    .innerJoin(citiesTable, eq(citiesTable.id, companionsTable.city_id))
+    .leftJoin(imagesTable, eq(imagesTable.companionId, companionsTable.id))
+    .where(eq(companionsTable.plan_type, 'do_dia'))
+    .limit(1);
+
+  if (!results.length) return null;
+  const row = results[0];
+  return {
+    id: row.id,
+    name: row.name,
+    age: row.age,
+    price: row.price,
+    shortDescription: row.shortDescription,
+    verified: row.verified,
+    city: row.city,
+    imageUrl: row.imageUrl,
+  };
+}
+
 export async function getRandomCompanions(
   plans?: PlanType[],
   citySlug?: string,

--- a/db/queries/companions.ts
+++ b/db/queries/companions.ts
@@ -270,8 +270,19 @@ export async function getDoDiaCompanion() {
     })
     .from(companionsTable)
     .innerJoin(citiesTable, eq(citiesTable.id, companionsTable.city_id))
-    .leftJoin(imagesTable, eq(imagesTable.companionId, companionsTable.id))
-    .where(eq(companionsTable.plan_type, 'do_dia'))
+    .leftJoin(
+      imagesTable,
+      and(
+        eq(imagesTable.companionId, companionsTable.id),
+        eq(imagesTable.is_verification_video, false),
+      ),
+    )
+    .where(
+      and(
+        eq(companionsTable.plan_type, 'do_dia'),
+        eq(companionsTable.verified, true),
+      ),
+    )
     .limit(1);
 
   if (!results.length) return null;


### PR DESCRIPTION
## Summary

Combines the changes from PRs #73, #74, #75, and #76 into a single PR (those PRs are being closed in favor of this one).

### "Sugar do dia" → "Exclusiva Onesugar" rename + dynamic homepage hero (was #73)
- Homepage hero now dynamically fetches and displays the featured ("do dia") companion — name, age, city, price, short description, verified badge, and photo — instead of a static badge image.
- Added an "Exclusiva Onesugar" pill label above the headline (desktop + mobile layouts).
- Featured companion's photo/card is now a clickable link to their profile.
- New `getDoDiaCompanion()` query in `db/queries/companions.ts`.
- Copy fix: "Contato" → "Contacto" (PT-PT spelling) in the WhatsApp button.

### Location city page fixes (was #74)
- Fixed a duplicate-function/parse error in `app/location/[city]/page.tsx`: removed a standalone `NearbyLinks` component and inlined its JSX at the call site.

### Registration/verification toast cleanup (was #75)
- Document verification success toast updated: title now "Perfil criado com sucesso!" with a clearer description.
- Removed two redundant "Perfil criado" toasts fired earlier in the registration flow (photo-upload step and first-step completion), consolidating to a single toast at the true end of the flow.

### Madeira location + SSG (was #76)
- Added Madeira as a new location with full editorial content.
- Added `generateStaticParams` so location pages are statically generated at build time instead of purely on-demand.

### Additional fix on top of the above
- `getDoDiaCompanion()` was missing two filters every other public-facing companion query in the file has:
  - Excluded verification photos/videos from the image join (previously could leak a verification asset as the public homepage hero image).
  - Added `verified: true` requirement (previously an unverified profile could be featured on the homepage).

## Test plan
- [x] `bun run build` completes successfully (all pages compile and prerender)
- [x] `tsc --noEmit` passes with no errors
- [x] Manually verified `/location/porto` renders the nearby-cities links correctly after the merge conflict resolution
- [x] Manual QA of the homepage hero with a real "do dia" companion in a review/staging environment
