### PR TITLE
Feat/verification two steps register

### DIFF
--- a/app/actions/admin-stories.ts
+++ b/app/actions/admin-stories.ts
@@ -26,6 +26,8 @@ export async function createStoryAction(
     const author = (formData.get('author') as string) || 'Onesugar';
     const readTime = parseInt(formData.get('readTime') as string) || 5;
     const featured = formData.get('featured') === 'true';
+    const publishedAtRaw = formData.get('publishedAt') as string | null;
+    const publishedAt = publishedAtRaw ? new Date(publishedAtRaw) : new Date();
     const paragraphCount = parseInt(formData.get('paragraphCount') as string) || 0;
 
     const paragraphs: string[] = [];
@@ -78,6 +80,7 @@ export async function createStoryAction(
       author,
       read_time: readTime,
       featured,
+      published_at: publishedAt,
       paragraphs,
       inline_images: inlineImages,
     });

--- a/app/admin/contos/new/new-story-form.tsx
+++ b/app/admin/contos/new/new-story-form.tsx
@@ -36,6 +36,7 @@ export function NewStoryForm({
   const [author, setAuthor] = useState('Onesugar');
   const [readTime, setReadTime] = useState(5);
   const [featured, setFeatured] = useState(false);
+  const [publishedAt, setPublishedAt] = useState(() => new Date().toISOString().split('T')[0]);
   const [coverFile, setCoverFile] = useState<File | null>(null);
   const [coverPreview, setCoverPreview] = useState('');
   const [paragraphs, setParagraphs] = useState<string[]>(['']);
@@ -108,6 +109,7 @@ export function NewStoryForm({
     fd.append('author', author);
     fd.append('readTime', String(readTime));
     fd.append('featured', String(featured));
+    fd.append('publishedAt', publishedAt);
     fd.append('paragraphCount', String(paragraphs.length));
     paragraphs.forEach((p, i) => fd.append(`paragraph_${i}`, p));
     if (coverFile) fd.append('coverImage', coverFile);
@@ -210,6 +212,16 @@ export function NewStoryForm({
               max={60}
               value={readTime}
               onChange={(e) => setReadTime(Number(e.target.value))}
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label htmlFor="publishedAt">Data de publicação</Label>
+            <Input
+              id="publishedAt"
+              type="date"
+              value={publishedAt}
+              onChange={(e) => setPublishedAt(e.target.value)}
             />
           </div>
 

--- a/app/companions/register/page.tsx
+++ b/app/companions/register/page.tsx
@@ -74,18 +74,14 @@ async function CompanionFormWithData() {
     redirect("/companions/verification/pending");
   }
 
-  // Only redirect to verification page if:
-  // 1. User is NOT already verified
-  // 2. Companion profile exists (registration completed)
-  // 3. Images are uploaded (completed registration form)
-  // 4. Verification video NOT uploaded yet
-  if (
-    !isVerified &&
-    companion &&
-    allVerificationStatus.isImageUploaded &&
-    !allVerificationStatus.isDocumentUploaded
-  ) {
-    redirect("/companions/verification");
+  // Route to the correct verification step based on what's already uploaded
+  if (!isVerified && companion && allVerificationStatus.isImageUploaded) {
+    if (!allVerificationStatus.isVerificationVideoUploaded) {
+      redirect("/companions/verification");
+    }
+    if (!allVerificationStatus.isDocumentUploaded) {
+      redirect("/companions/verification/document");
+    }
   }
 
   return (

--- a/app/companions/register/page.tsx
+++ b/app/companions/register/page.tsx
@@ -13,7 +13,6 @@ import { eq } from "drizzle-orm";
 import { redirect } from "next/navigation";
 import { Suspense } from "react";
 import type { Metadata } from "next";
-import { EarningsCalculator } from "@/components/earnings-calculator";
 
 export const metadata: Metadata = {
   title: 'Cadastre-se agora | One Sugar',
@@ -99,7 +98,6 @@ export default async function RegisterCompanionPage() {
         <h1 className="text-2xl font-bold">Torne-se uma Sugar na Onesugar</h1>
         <p className="text-sm text-muted-foreground">Perfis verificados. Visibilidade real. 100% dos ganhos para si.</p>
       </div>
-      <EarningsCalculator />
       <div id="register-form">
         <Suspense fallback={<SkeletonForm />}>
           <CompanionFormWithData />

--- a/app/companions/verification/document/page.tsx
+++ b/app/companions/verification/document/page.tsx
@@ -1,6 +1,8 @@
 import { auth } from '@clerk/nextjs/server';
 import { redirect } from 'next/navigation';
-import { getCompanionByClerkId } from '@/db/queries/companions';
+import { db } from '@/db';
+import { companionsTable } from '@/db/schema';
+import { eq } from 'drizzle-orm';
 import { isVerificationPending, verifyItemsIfOnboardingComplete } from '@/app/actions/document-verification';
 import { DocumentUploadForm } from '@/components/document-upload-form';
 
@@ -11,7 +13,13 @@ export default async function DocumentVerificationPage() {
 
   if (!userId) redirect('/');
 
-  const companion = await getCompanionByClerkId(userId).catch(() => null);
+  const [companion] = await db
+    .select({ id: companionsTable.id })
+    .from(companionsTable)
+    .where(eq(companionsTable.auth_id, userId))
+    .limit(1)
+    .catch(() => [null]);
+
   if (!companion) redirect('/companions/register');
 
   const [isPending, uploadStatus] = await Promise.all([

--- a/app/companions/verification/document/page.tsx
+++ b/app/companions/verification/document/page.tsx
@@ -2,11 +2,11 @@ import { auth } from '@clerk/nextjs/server';
 import { redirect } from 'next/navigation';
 import { getCompanionByClerkId } from '@/db/queries/companions';
 import { isVerificationPending, verifyItemsIfOnboardingComplete } from '@/app/actions/document-verification';
-import { VideoVerificationForm } from '@/components/video-verification-form';
+import { DocumentUploadForm } from '@/components/document-upload-form';
 
 export const dynamic = 'force-dynamic';
 
-export default async function VideoVerificationPage() {
+export default async function DocumentVerificationPage() {
   const { userId } = await auth();
 
   if (!userId) redirect('/');
@@ -21,23 +21,23 @@ export default async function VideoVerificationPage() {
 
   if (isPending) redirect('/companions/verification/pending');
 
-  // If video already uploaded, go straight to document step
-  if (uploadStatus.isVerificationVideoUploaded && !uploadStatus.isDocumentUploaded) {
-    redirect('/companions/verification/document');
+  // Must upload video first
+  if (!uploadStatus.isVerificationVideoUploaded) {
+    redirect('/companions/verification');
   }
 
   return (
     <div className="container mx-auto py-12 px-4">
       {/* Step indicator */}
       <div className="flex items-center gap-2 mb-10 text-sm font-semibold text-muted-foreground">
-        <span className="bg-rose-600 text-white rounded-full w-6 h-6 flex items-center justify-center text-xs font-bold">1</span>
-        <span className="text-foreground">Vídeo de Verificação</span>
+        <span className="bg-muted text-muted-foreground rounded-full w-6 h-6 flex items-center justify-center text-xs font-bold">1</span>
+        <span className="line-through">Vídeo de Verificação</span>
         <span className="mx-2">→</span>
-        <span className="bg-muted rounded-full w-6 h-6 flex items-center justify-center text-xs font-bold">2</span>
-        <span>Documento de Identificação</span>
+        <span className="bg-rose-600 text-white rounded-full w-6 h-6 flex items-center justify-center text-xs font-bold">2</span>
+        <span className="text-foreground">Documento de Identificação</span>
       </div>
 
-      <VideoVerificationForm initialVideoUploaded={uploadStatus.isVerificationVideoUploaded} />
+      <DocumentUploadForm />
     </div>
   );
 }

--- a/app/companions/verification/page.tsx
+++ b/app/companions/verification/page.tsx
@@ -1,6 +1,8 @@
 import { auth } from '@clerk/nextjs/server';
 import { redirect } from 'next/navigation';
-import { getCompanionByClerkId } from '@/db/queries/companions';
+import { db } from '@/db';
+import { companionsTable } from '@/db/schema';
+import { eq } from 'drizzle-orm';
 import { isVerificationPending, verifyItemsIfOnboardingComplete } from '@/app/actions/document-verification';
 import { VideoVerificationForm } from '@/components/video-verification-form';
 
@@ -11,7 +13,13 @@ export default async function VideoVerificationPage() {
 
   if (!userId) redirect('/');
 
-  const companion = await getCompanionByClerkId(userId).catch(() => null);
+  const [companion] = await db
+    .select({ id: companionsTable.id })
+    .from(companionsTable)
+    .where(eq(companionsTable.auth_id, userId))
+    .limit(1)
+    .catch(() => [null]);
+
   if (!companion) redirect('/companions/register');
 
   const [isPending, uploadStatus] = await Promise.all([

--- a/app/contos/[slug]/page.tsx
+++ b/app/contos/[slug]/page.tsx
@@ -95,10 +95,18 @@ export default async function StoryPage({
           {story.collection}
         </span>
         <h1 className="text-4xl font-extrabold tracking-tight">{story.title}</h1>
-        <div className="flex items-center gap-3 text-sm text-muted-foreground">
+        <div className="flex items-center gap-3 text-sm text-muted-foreground flex-wrap">
           <span>{story.author}</span>
           <span>·</span>
           <span>{story.readTime} min de leitura</span>
+          <span>·</span>
+          <span>
+            {new Date(story.publishedAt).toLocaleDateString('pt-PT', {
+              day: 'numeric',
+              month: 'long',
+              year: 'numeric',
+            })}
+          </span>
         </div>
       </div>
 

--- a/app/contos/page.tsx
+++ b/app/contos/page.tsx
@@ -1,7 +1,15 @@
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import Image from 'next/image';
-import { Clock, Flame, Send, Sparkles } from 'lucide-react';
+import { Clock, Flame, Send, Sparkles, CalendarDays } from 'lucide-react';
+
+function formatDate(dateStr: string): string {
+  return new Date(dateStr).toLocaleDateString('pt-PT', {
+    day: 'numeric',
+    month: 'short',
+    year: 'numeric',
+  });
+}
 import { stories as staticStories, isNew, dbToStory } from '@/lib/stories';
 import { getAllStoryViews } from '@/app/actions/story-views';
 import { getAllDbStories } from '@/db/queries/stories';
@@ -313,6 +321,10 @@ function LatestStoryCard({
             <Clock className="h-3 w-3" />
             <span className="text-xs">{story.readTime} min</span>
           </div>
+          <div className="flex items-center gap-1 text-muted-foreground">
+            <CalendarDays className="h-3 w-3" />
+            <span className="text-xs">{formatDate(story.publishedAt)}</span>
+          </div>
         </div>
       </article>
     </Link>
@@ -364,6 +376,10 @@ function MostReadCard({
             {views > 0 && (
               <span className="text-xs text-muted-foreground">{views} leituras</span>
             )}
+          </div>
+          <div className="flex items-center gap-1 text-muted-foreground">
+            <CalendarDays className="h-3 w-3" />
+            <span className="text-xs">{formatDate(story.publishedAt)}</span>
           </div>
         </div>
       </article>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -140,7 +140,7 @@ export default function RootLayout({
               ],
               contactPoint: {
                 '@type': 'ContactPoint',
-                telephone: '+351 934 600 827',
+                telephone: '+351 913 895 353',
                 contactType: 'customer service',
               },
             }),

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,10 +1,12 @@
 import { MetadataRoute } from 'next';
 import { getAvailableCities } from '@/db/queries';
 
+export const dynamic = 'force-dynamic';
+
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const baseUrl = 'https://www.onesugar.pt';
 
-  const cities = await getAvailableCities();
+  const cities = await getAvailableCities().catch(() => []);
 
   const cityUrls = cities.map(city => ({
     url: `${baseUrl}/location/${city.slug}`,

--- a/components/document-upload-form.tsx
+++ b/components/document-upload-form.tsx
@@ -220,6 +220,18 @@ export function DocumentUploadForm() {
             )}
           />
 
+          {/* Security notice */}
+          <div className="rounded-xl border border-border bg-muted/40 px-5 py-4 space-y-2">
+            <p className="text-sm font-bold">
+              A sua segurança é importante
+            </p>
+            <ul className="space-y-1.5 text-sm text-muted-foreground">
+              <li>Todos os dados enviados são encriptados e utilizados exclusivamente para o processo de verificação da sua conta.</li>
+              <li>Nunca partilhamos as suas informações com terceiros.</li>
+              <li>O nosso compromisso é garantir a sua privacidade, segurança e confidencialidade em todas as etapas da verificação.</li>
+            </ul>
+          </div>
+
           <Button
             type="submit"
             size="lg"

--- a/components/document-upload-form.tsx
+++ b/components/document-upload-form.tsx
@@ -1,0 +1,245 @@
+"use client";
+
+import * as React from "react";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  getSignedUploadUrl,
+  saveDocumentAfterUpload,
+} from "@/app/actions/document-verification";
+import { useUser } from "@clerk/nextjs";
+import { useToast } from "@/hooks/use-toast";
+import { Loader2, Upload, ShieldCheck } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useRouter } from "next/navigation";
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024;
+
+const DocumentFormSchema = z.object({
+  documentType: z.string().min(1, "Selecione um tipo de documento"),
+  file: z
+    .any()
+    .refine((file) => file instanceof File, { message: "Envie um ficheiro válido" })
+    .refine((file) => file.size <= MAX_FILE_SIZE, {
+      message: "O ficheiro deve ter no máximo 5MB",
+    }),
+});
+
+async function uploadDocumentToSupabase(
+  file: File,
+  documentType: string,
+): Promise<{ success: true } | { success: false; error: string }> {
+  const fileExtension = file.name.split(".").pop() || "bin";
+  const signedUrlResult = await getSignedUploadUrl(documentType, fileExtension);
+
+  if (!signedUrlResult.success) {
+    return { success: false, error: signedUrlResult.error ?? "Falha ao gerar URL de upload." };
+  }
+
+  const { signedUrl, storagePath } = signedUrlResult;
+
+  const uploadResponse = await fetch(signedUrl, {
+    method: "PUT",
+    headers: { "Content-Type": file.type },
+    body: file,
+  });
+
+  if (!uploadResponse.ok) {
+    const errorText = await uploadResponse.text().catch(() => "Erro desconhecido");
+    return { success: false, error: `Erro no upload: ${errorText}` };
+  }
+
+  const saveResult = await saveDocumentAfterUpload(documentType, storagePath);
+  if (!saveResult.success) {
+    return { success: false, error: saveResult.error ?? "Falha ao guardar registo do documento." };
+  }
+
+  return { success: true };
+}
+
+export function DocumentUploadForm() {
+  const { isLoaded, user } = useUser();
+  const { toast } = useToast();
+  const router = useRouter();
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
+  const fileInputRef = React.useRef<HTMLInputElement>(null);
+
+  const form = useForm<z.infer<typeof DocumentFormSchema>>({
+    resolver: zodResolver(DocumentFormSchema),
+    defaultValues: { documentType: "" },
+  });
+
+  async function onSubmit(data: z.infer<typeof DocumentFormSchema>) {
+    if (!isLoaded || !user?.id) {
+      toast({ title: "Erro", description: "Utilizador não autenticado.", variant: "destructive" });
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const result = await uploadDocumentToSupabase(data.file, data.documentType);
+
+      if (result.success) {
+        toast({
+          title: "Perfil criado com sucesso!",
+          description: "Os seus documentos foram enviados e o perfil está a ser verificado pela nossa equipa.",
+          variant: "success",
+        });
+        router.push("/companions/verification/pending");
+      } else {
+        toast({ title: "Erro", description: result.error, variant: "destructive" });
+      }
+    } catch (error) {
+      toast({
+        title: "Erro",
+        description: error instanceof Error ? error.message : "Ocorreu um erro ao enviar o documento.",
+        variant: "destructive",
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="w-full max-w-2xl mx-auto space-y-8">
+      {/* Header */}
+      <div className="space-y-3">
+        <div className="flex flex-wrap items-center gap-3">
+          <h1 className="text-3xl font-extrabold tracking-tight">Documento de Identificação</h1>
+          <span className="bg-rose-600 text-white text-sm font-extrabold px-4 py-1.5 rounded-full uppercase tracking-widest shrink-0">
+            Obrigatório
+          </span>
+        </div>
+        <p className="text-xl font-semibold leading-snug text-foreground">
+          Envie um documento oficial que possamos identificar que você tem idade mínima de 18 anos.
+        </p>
+      </div>
+
+      {/* Accepted documents */}
+      <div className="border-2 border-border rounded-xl p-6 space-y-3 bg-muted/40">
+        <h2 className="text-lg font-bold">Documentos aceites:</h2>
+        <ul className="space-y-2 text-base font-medium text-foreground/80">
+          <li className="flex items-start gap-2">
+            <span className="text-rose-500 mt-0.5 shrink-0">•</span>
+            Passaporte
+          </li>
+          <li className="flex items-start gap-2">
+            <span className="text-rose-500 mt-0.5 shrink-0">•</span>
+            Cartão de Cidadão (Portugal)
+          </li>
+          <li className="flex items-start gap-2">
+            <span className="text-rose-500 mt-0.5 shrink-0">•</span>
+            RG ou qualquer outro documento oficial que permita confirmar que você é maior de idade.
+          </li>
+        </ul>
+      </div>
+
+      {/* Privacy note */}
+      <div className="border-2 border-amber-300 bg-amber-50 dark:bg-amber-950/20 rounded-xl p-6 flex gap-4">
+        <ShieldCheck className="h-6 w-6 text-amber-600 shrink-0 mt-0.5" />
+        <div className="space-y-1">
+          <h3 className="font-bold text-base text-amber-900 dark:text-amber-400">Observação</h3>
+          <p className="text-sm font-medium text-amber-800 dark:text-amber-300 leading-relaxed">
+            Solicitamos este requisito para segurança e evitarmos perfis falsificados, inclusive,
+            evitando menores. Por isso, precisamos fazer este tipo de solicitação.
+          </p>
+        </div>
+      </div>
+
+      {/* Form */}
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+          <FormField
+            control={form.control}
+            name="documentType"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel className="text-base font-bold">Tipo de Documento</FormLabel>
+                <Select onValueChange={field.onChange} defaultValue={field.value}>
+                  <FormControl>
+                    <SelectTrigger className="h-12 text-base">
+                      <SelectValue placeholder="Selecione o tipo de documento" />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    <SelectItem value="passport">Passaporte</SelectItem>
+                    <SelectItem value="id_card">Cartão de Cidadão / RG</SelectItem>
+                    <SelectItem value="drivers_license">Carta de Condução / CNH</SelectItem>
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="file"
+            render={({ field: { onChange } }) => (
+              <FormItem>
+                <FormLabel className="text-base font-bold">Ficheiro (máx. 5MB)</FormLabel>
+                <FormControl>
+                  <Input
+                    type="file"
+                    ref={fileInputRef}
+                    className="h-12 text-base cursor-pointer"
+                    onChange={(e) => {
+                      const file = e.target.files?.[0];
+                      if (file) {
+                        onChange(file);
+                        if (file.size > MAX_FILE_SIZE) {
+                          form.setError("file", { message: "O ficheiro deve ter no máximo 5MB" });
+                        } else {
+                          form.clearErrors("file");
+                        }
+                      }
+                    }}
+                    accept="image/jpeg,image/png,application/pdf"
+                  />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <Button
+            type="submit"
+            size="lg"
+            className="w-full text-base font-bold py-6"
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? (
+              <>
+                <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+                A enviar documento...
+              </>
+            ) : (
+              <>
+                <Upload className="mr-2 h-5 w-5" />
+                Enviar Documento
+              </>
+            )}
+          </Button>
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -38,7 +38,7 @@ export default function Footer() {
                 <strong>Endereço:</strong> Lisboa, Portugal
               </p>
               <p>
-                <strong>Telefone:</strong> +351 934 600 827
+                <strong>Telefone:</strong> +351 913 895 353
 
               </p>
             </div>

--- a/components/formCompanionRegister.tsx
+++ b/components/formCompanionRegister.tsx
@@ -67,6 +67,7 @@ import { cn } from "@/lib/utils";
 import { IconBrandInstagram, IconLanguage } from "@tabler/icons-react";
 import { registerCompanionAction } from "@/app/actions/register";
 import { completeFirstStepRegistration } from "@/app/companions/register/action";
+import { EarningsCalculator } from "@/components/earnings-calculator";
 
 const pageOneSchema = z.object({
   // Companion Info
@@ -261,7 +262,7 @@ export function RegisterCompanionForm({
         piercings: false,
         smoker: false,
         neighborhood: "",
-        city: 1,
+        city: 0,
         state: "",
         country: "",
         meets_at_hotel: false,
@@ -481,12 +482,29 @@ export function RegisterCompanionForm({
 
   return (
     <div className="min-h-screen bg-background p-4 md:p-6 lg:p-8">
+      {!companionData && currentPage === 0 && (
+        <div className="mx-auto max-w-3xl mb-8">
+          <EarningsCalculator
+            cta={
+              <button
+                type="button"
+                onClick={() =>
+                  document.getElementById("form-fields")?.scrollIntoView({ behavior: "smooth" })
+                }
+                className="w-full bg-rose-600 hover:bg-rose-700 text-white font-semibold py-3 rounded-xl transition-colors text-sm"
+              >
+                Criar o meu perfil de Sugar gratuitamente
+              </button>
+            }
+          />
+        </div>
+      )}
       <Form {...form}>
         <form
           onSubmit={form.handleSubmit(onSubmit)}
           className="mx-auto max-w-3xl"
         >
-          <Card>
+          <Card id="form-fields">
             <CardHeader>
               <CardTitle>
                 {companionData ? "Edit Profile" : "Registre-se"}
@@ -503,7 +521,7 @@ export function RegisterCompanionForm({
                 <div className="w-full aspect-video">
                   <iframe
                     className="w-full h-full rounded-lg border shadow-sm"
-                    src="https://youtube.com/embed/m5Tja4hJMXQ?autoplay=1&controls=0&mute=0&loop=1&playlist=m5Tja4hJMXQ&modestbranding=1&showinfo=0&rel=0"
+                    src="https://www.youtube-nocookie.com/embed/m5Tja4hJMXQ?autoplay=1&controls=0&mute=0&loop=1&playlist=m5Tja4hJMXQ&modestbranding=1&showinfo=0&rel=0"
                     title="Vídeo de verificação"
                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                     allowFullScreen

--- a/components/story-card.tsx
+++ b/components/story-card.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 import Image from 'next/image';
+import { CalendarDays } from 'lucide-react';
 import type { Story } from '@/lib/stories';
 
 export function StoryCard({ story }: { story: Story }) {
@@ -40,6 +41,16 @@ export function StoryCard({ story }: { story: Story }) {
           <div className="flex items-center justify-between pt-1">
             <span className="text-xs text-muted-foreground">{story.author}</span>
             <span className="text-xs text-muted-foreground">{story.readTime} min</span>
+          </div>
+          <div className="flex items-center gap-1 text-muted-foreground pt-0.5">
+            <CalendarDays className="h-3 w-3" />
+            <span className="text-xs">
+              {new Date(story.publishedAt).toLocaleDateString('pt-PT', {
+                day: 'numeric',
+                month: 'short',
+                year: 'numeric',
+              })}
+            </span>
           </div>
         </div>
       </article>

--- a/components/video-verification-form.tsx
+++ b/components/video-verification-form.tsx
@@ -1,0 +1,206 @@
+"use client";
+
+import * as React from "react";
+import {
+  getSignedUploadUrl,
+  saveDocumentAfterUpload,
+  getDocumentsByAuthId,
+} from "@/app/actions/document-verification";
+import { useUser } from "@clerk/nextjs";
+import { useToast } from "@/hooks/use-toast";
+import { Loader2, Check, VideoIcon, AlertCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { useRouter } from "next/navigation";
+
+const MAX_VIDEO_SIZE = 50 * 1024 * 1024;
+
+async function uploadVideoToSupabase(
+  file: File,
+): Promise<{ success: true } | { success: false; error: string }> {
+  const fileExtension = file.name.split(".").pop() || "mp4";
+  const signedUrlResult = await getSignedUploadUrl("verification_video", fileExtension);
+
+  if (!signedUrlResult.success) {
+    return { success: false, error: signedUrlResult.error ?? "Falha ao gerar URL de upload." };
+  }
+
+  const { signedUrl, storagePath } = signedUrlResult;
+
+  const uploadResponse = await fetch(signedUrl, {
+    method: "PUT",
+    headers: { "Content-Type": file.type },
+    body: file,
+  });
+
+  if (!uploadResponse.ok) {
+    const errorText = await uploadResponse.text().catch(() => "Erro desconhecido");
+    return { success: false, error: `Erro no upload: ${errorText}` };
+  }
+
+  const saveResult = await saveDocumentAfterUpload("verification_video", storagePath);
+  if (!saveResult.success) {
+    return { success: false, error: saveResult.error ?? "Falha ao guardar registo do vídeo." };
+  }
+
+  return { success: true };
+}
+
+export function VideoVerificationForm({
+  initialVideoUploaded,
+}: {
+  initialVideoUploaded: boolean;
+}) {
+  const { isLoaded, user } = useUser();
+  const { toast } = useToast();
+  const router = useRouter();
+  const [videoUploaded, setVideoUploaded] = React.useState(initialVideoUploaded);
+  const [isUploading, setIsUploading] = React.useState(false);
+  const [uploadProgress, setUploadProgress] = React.useState("");
+  const inputRef = React.useRef<HTMLInputElement>(null);
+
+  async function handleVideoUpload(file: File) {
+    if (!isLoaded || !user?.id) return;
+
+    if (file.size > MAX_VIDEO_SIZE) {
+      toast({
+        title: "Vídeo demasiado grande",
+        description: "O vídeo deve ter no máximo 50MB. Comprima-o antes de enviar.",
+        variant: "destructive",
+      });
+      if (inputRef.current) inputRef.current.value = "";
+      return;
+    }
+
+    if (!file.type.startsWith("video/")) {
+      toast({
+        title: "Formato inválido",
+        description: "Por favor, envie um ficheiro de vídeo válido.",
+        variant: "destructive",
+      });
+      if (inputRef.current) inputRef.current.value = "";
+      return;
+    }
+
+    setIsUploading(true);
+    setUploadProgress("A enviar vídeo...");
+
+    try {
+      const result = await uploadVideoToSupabase(file);
+
+      if (result.success) {
+        const updated = await getDocumentsByAuthId(user.id);
+        if (updated.success) setVideoUploaded(true);
+
+        toast({
+          title: "Vídeo enviado!",
+          description: "Pode agora enviar o documento de identificação.",
+          variant: "success",
+        });
+
+        router.push("/companions/verification/document");
+      } else {
+        toast({ title: "Erro", description: result.error, variant: "destructive" });
+        if (inputRef.current) inputRef.current.value = "";
+      }
+    } catch (error) {
+      toast({
+        title: "Erro",
+        description: error instanceof Error ? error.message : "Ocorreu um erro ao enviar o vídeo.",
+        variant: "destructive",
+      });
+      if (inputRef.current) inputRef.current.value = "";
+    } finally {
+      setIsUploading(false);
+      setUploadProgress("");
+    }
+  }
+
+  return (
+    <div className="w-full max-w-2xl mx-auto space-y-8">
+      {/* Header */}
+      <div className="space-y-3">
+        <div className="flex flex-wrap items-center gap-3">
+          <h1 className="text-3xl font-extrabold tracking-tight">Vídeo 360° com um papel</h1>
+          <span className="bg-rose-600 text-white text-sm font-extrabold px-4 py-1.5 rounded-full uppercase tracking-widest shrink-0">
+            Obrigatório
+          </span>
+        </div>
+        <p className="text-xl font-semibold leading-snug text-foreground">
+          Grave um vídeo 360° mostrando claramente o seu rosto e corpo, segurando um papel com
+          a palavra <span className="text-rose-500">"OneSugar"</span> e a data de hoje.
+        </p>
+      </div>
+
+      {/* Observations */}
+      <div className="border-2 border-border rounded-xl p-6 space-y-4 bg-muted/40">
+        <h2 className="text-lg font-bold">Observações para o vídeo:</h2>
+        <ul className="space-y-2.5 text-base font-medium text-foreground/80">
+          <li className="flex items-start gap-2">
+            <span className="text-rose-500 mt-0.5 shrink-0">•</span>
+            Mostre todo o seu corpo e rosto com boa iluminação.
+          </li>
+          <li className="flex items-start gap-2">
+            <span className="text-rose-500 mt-0.5 shrink-0">•</span>
+            Segure um papel com a palavra <strong>"OneSugar"</strong> e a data de hoje.
+          </li>
+          <li className="flex items-start gap-2">
+            <span className="text-rose-500 mt-0.5 shrink-0">•</span>
+            O vídeo deve ter entre 10 e 15 segundos e no máximo 50MB.
+          </li>
+        </ul>
+
+        <div className="pt-2 border-t border-border">
+          <p className="text-sm text-muted-foreground font-medium">
+            Se o seu vídeo for maior que 50MB, comprima-o antes de enviar:
+            <span className="block mt-1">
+              iPhone: <strong>Video Compress</strong> · Android: <strong>Video Compressor</strong> · Online: <strong>clideo.com</strong>
+            </span>
+          </p>
+        </div>
+      </div>
+
+      {/* Upload area */}
+      {videoUploaded ? (
+        <div className="flex flex-col items-center gap-3 py-10 border-2 border-orange-300 bg-orange-50 dark:bg-orange-950/20 rounded-xl">
+          <AlertCircle className="h-10 w-10 text-orange-500" />
+          <p className="text-xl font-bold text-orange-700 dark:text-orange-400">Pendente de aprovação</p>
+          <p className="text-sm text-muted-foreground">O seu vídeo foi recebido e está a ser analisado pela nossa equipa.</p>
+        </div>
+      ) : (
+        <div className="flex flex-col items-center gap-4">
+          <Input
+            ref={inputRef}
+            type="file"
+            accept="video/*"
+            className="hidden"
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (file) handleVideoUpload(file);
+            }}
+            disabled={isUploading}
+          />
+          <Button
+            type="button"
+            size="lg"
+            className="w-full text-base font-bold py-6"
+            onClick={() => inputRef.current?.click()}
+            disabled={isUploading}
+          >
+            {isUploading ? (
+              <>
+                <Loader2 className="mr-2 h-5 w-5 animate-spin" />
+                {uploadProgress || "A enviar vídeo..."}
+              </>
+            ) : (
+              <>
+                <VideoIcon className="mr-2 h-5 w-5" />
+                Escolher vídeo
+              </>
+            )}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/video-verification-form.tsx
+++ b/components/video-verification-form.tsx
@@ -195,7 +195,7 @@ export function VideoVerificationForm({
             ) : (
               <>
                 <VideoIcon className="mr-2 h-5 w-5" />
-                Escolher vídeo
+                Enviar vídeo
               </>
             )}
           </Button>

--- a/components/whatsapp-button.tsx
+++ b/components/whatsapp-button.tsx
@@ -9,7 +9,7 @@ interface WhatsAppButtonProps {
 }
 
 export const WhatsAppButton = ({
-  phoneNumber = '351934600827',
+  phoneNumber = '351913895353',
   message = '',
 }: WhatsAppButtonProps) => {
   const whatsappUrl = `https://wa.me/${phoneNumber}${message ? `?text=${encodeURIComponent(message)}` : ''


### PR DESCRIPTION

### Verificação em 2 passos
- Step 1 (`/companions/verification`): upload do vídeo 360° com instruções e badge "Obrigatório"
- Step 2 (`/companions/verification/document`): upload do documento de identificação com aviso de privacidade
- Após upload do vídeo → redireciona automaticamente para o step 2
- Após upload do documento → redireciona para `/companions/verification/pending`
- `/companions/register` redireciona para o step correto consoante o progresso da companion

### Melhorias no formulário de registo
- `EarningsCalculator` aparece apenas no passo 1 do formulário, desaparece nos passos seguintes
- Fix: URL do YouTube corrigido para `youtube-nocookie.com` (o domínio `youtube.com` estava bloqueado pelo CSP)
- Fix: default de `city` alterado de `1` para `0` — o Select mostrava Lisboa pré-selecionado mas `state` e `country` ficavam vazios, causando falha silenciosa na validação da página de Localização

## New files
- `components/video-verification-form.tsx`
- `components/document-upload-form.tsx`
- `app/companions/verification/document/page.tsx`

## Test plan
- [ ] Nova companion: onboarding → registo → `/companions/verification` (vídeo) → `/companions/verification/document` (documento) → pending
- [ ] Calculadora aparece no passo 1 do registo e desaparece ao avançar
- [ ] Vídeo de exemplo carrega no formulário de registo
- [ ] Selecionar distrito na página de Localização permite avançar para o passo seguinte
- [ ] Companion com vídeo já enviado é redirecionada diretamente para o step 2 do documento