### PR TITLE
feat: sync companions to RD Station Marketing (leads + status tags)

### DIFF
--- a/db/queries/companions.ts
+++ b/db/queries/companions.ts
@@ -15,6 +15,7 @@ import {
 import { db } from "..";
 import { RegisterCompanionFormValues } from "@/components/formCompanionRegister";
 import { auth, clerkClient } from "@clerk/nextjs/server";
+import { upsertContactInRD, tagCompanionInRD } from "@/lib/rd-station";
 import {
   CompanionFiltered,
   CompanionPreview,
@@ -535,6 +536,8 @@ export async function registerCompanion(
       return companion;
     });
 
+    await upsertContactInRD({ email, name, phone: phoneNumber });
+
     return JSON.parse(JSON.stringify(newCompanion));
   } catch (error) {
     console.error("Failed to register companion in DB:", error);
@@ -777,9 +780,11 @@ export async function updateCompanionFromForm(
   clerkId: string,
   data: RegisterCompanionFormValues,
 ) {
+  let email: string | undefined;
+
   await db.transaction(async (tx) => {
     // Update companionsTable
-    await tx
+    const [companion] = await tx
       .update(companionsTable)
       .set({
         name: data.name,
@@ -798,7 +803,10 @@ export async function updateCompanionFromForm(
         verified: false,
         updated_at: new Date(),
       } as NewCompanion)
-      .where(eq(companionsTable.auth_id, clerkId));
+      .where(eq(companionsTable.auth_id, clerkId))
+      .returning({ id: companionsTable.id, email: companionsTable.email });
+
+    email = companion?.email;
 
     await tx
       .update(characteristicsTable)
@@ -815,19 +823,12 @@ export async function updateCompanionFromForm(
         piercings: data.piercings,
         smoker: data.smoker,
       } as NewCharacteristic)
-      .where(
-        eq(
-          characteristicsTable.companion_id,
-          (
-            await tx
-              .select({ id: companionsTable.id })
-              .from(companionsTable)
-              .where(eq(companionsTable.auth_id, clerkId))
-              .limit(1)
-          )[0].id,
-        ),
-      );
+      .where(eq(characteristicsTable.companion_id, companion.id));
   });
+
+  if (email) {
+    await upsertContactInRD({ email, name: data.name, phone: data.phoneNumber });
+  }
 }
 
 export async function getUnverifiedCompanions(): Promise<
@@ -942,18 +943,33 @@ export async function getUnverifiedCompanions(): Promise<
 }
 
 export async function approveCompanion(id: number) {
-  await db
+  const [companion] = await db
     .update(companionsTable)
     .set({ verified: true })
-    .where(eq(companionsTable.id, id));
+    .where(eq(companionsTable.id, id))
+    .returning({ email: companionsTable.email });
+
+  if (companion?.email) {
+    await tagCompanionInRD(companion.email, "aprovado");
+  }
 
   return { success: true, id };
 }
 
 export async function rejectCompanion(id: number) {
+  let email: string | undefined;
+
   await db.transaction(async (tx) => {
-    await tx.delete(companionsTable).where(eq(companionsTable.id, id));
+    const [companion] = await tx
+      .delete(companionsTable)
+      .where(eq(companionsTable.id, id))
+      .returning({ email: companionsTable.email });
+    email = companion?.email;
   });
+
+  if (email) {
+    await tagCompanionInRD(email, "recusado");
+  }
 
   return { success: true, id };
 }

--- a/lib/rd-station.ts
+++ b/lib/rd-station.ts
@@ -1,0 +1,108 @@
+const RD_TOKEN_URL = 'https://api.rd.services/auth/token';
+const RD_CONTACTS_URL = 'https://api.rd.services/platform/contacts';
+
+let cachedAccessToken: { token: string; expiresAt: number } | null = null;
+
+async function getAccessToken(): Promise<string> {
+  if (cachedAccessToken && cachedAccessToken.expiresAt > Date.now()) {
+    return cachedAccessToken.token;
+  }
+
+  const response = await fetch(RD_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      client_id: process.env.RD_STATION_CLIENT_ID,
+      client_secret: process.env.RD_STATION_CLIENT_SECRET,
+      refresh_token: process.env.RD_STATION_REFRESH_TOKEN,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`RD Station: falha ao renovar access token (${response.status})`);
+  }
+
+  const data = await response.json();
+  cachedAccessToken = {
+    token: data.access_token,
+    // renova 60s antes de expirar, por segurança
+    expiresAt: Date.now() + (data.expires_in - 60) * 1000,
+  };
+  return cachedAccessToken.token;
+}
+
+/**
+ * Cria (se ainda não existir) ou atualiza o lead no RD Station, identificado
+ * pelo e-mail. Usado tanto no cadastro quanto em qualquer edição de perfil,
+ * para manter nome/telefone sincronizados. Não usa POST /platform/contacts
+ * (esse endpoint só cria — falha com EMAIL_ALREADY_IN_USE se o lead já existir).
+ */
+export async function upsertContactInRD(contact: {
+  email: string;
+  name?: string;
+  phone?: string;
+}): Promise<void> {
+  if (!process.env.RD_STATION_CLIENT_ID) return;
+
+  try {
+    const accessToken = await getAccessToken();
+    const contactUrl = `${RD_CONTACTS_URL}/email:${encodeURIComponent(contact.email)}`;
+
+    // Ao atualizar por e-mail, o campo "email" não deve ir no corpo.
+    const body: Record<string, string> = {};
+    if (contact.name) body.name = contact.name;
+    if (contact.phone) body.mobile_phone = contact.phone;
+
+    const response = await fetch(contactUrl, {
+      method: 'PATCH',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!response.ok) {
+      console.error(
+        `RD Station: falha ao sincronizar lead ${contact.email} (${response.status})`,
+      );
+    }
+  } catch (error) {
+    console.error('RD Station: erro ao sincronizar lead', error);
+  }
+}
+
+/**
+ * Marca um contacto no RD Station com a tag "aprovado" ou "recusado".
+ * As tags são cumulativas na API do RD Station (não substituem as
+ * existentes), e as automações de e-mail (boas-vindas / perfil recusado)
+ * já estão configuradas para disparar quando a tag é adicionada.
+ */
+export async function tagCompanionInRD(
+  email: string,
+  tag: 'aprovado' | 'recusado',
+): Promise<void> {
+  if (!process.env.RD_STATION_CLIENT_ID) return;
+
+  try {
+    const accessToken = await getAccessToken();
+    const tagUrl = `${RD_CONTACTS_URL}/email:${encodeURIComponent(email)}/tag`;
+
+    const response = await fetch(tagUrl, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ tags: [tag] }),
+    });
+
+    if (!response.ok) {
+      console.error(
+        `RD Station: falha ao marcar tag "${tag}" para ${email} (${response.status})`,
+      );
+    }
+  } catch (error) {
+    console.error('RD Station: erro ao sincronizar tag', error);
+  }
+}


### PR DESCRIPTION
Sends companions to RD Station as leads on registration and keeps name/phone in sync on profile edits (PATCH upsert, since the create-only endpoint errors on existing emails). Tags the contact "aprovado" or "recusado" when an admin approves/rejects a profile, triggering the welcome/rejected-profile automation flows already configured in RD Station. All calls are best-effort — failures are logged but never block registration or the admin review flow.