### PR TITLE
fix: resolve H1 duplicado na home, mantem h1 no bloco mobile e rebaix…

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -78,7 +78,7 @@ export default async function HomePage() {
         {/* ── HERO ── */}
         {/* Desktop: full-bleed background image (anchored right), text overlay on the left */}
         {/* Mobile: image on top, text block below */}
-        <section aria-labelledby="hero-heading">
+        <section aria-labelledby="hero-heading-mobile">
 
           {/* ── DESKTOP (md+): gradient background, two-column layout ── */}
           <div className="relative hidden md:flex items-center w-full min-h-[52vh] lg:min-h-[80vh] overflow-hidden">
@@ -94,12 +94,11 @@ export default async function HomePage() {
 
               {/* LEFT: text */}
               <div className="space-y-6">
-                <h1
-                  id="hero-heading"
+                <p
                   className="text-3xl md:text-4xl lg:text-5xl xl:text-6xl font-bold tracking-tighter text-white"
                 >
                   {h1Text}
-                </h1>
+                </p>
                 <h2 className="text-base md:text-lg text-white/70 max-w-md">
                   Descubra as acompanhantes mais sofisticadas de Portugal com total discrição e segurança.
                 </h2>


### PR DESCRIPTION
Título: fix: resolve H1 duplicado no hero da home

O hero da home renderiza dois blocos responsivos (desktop e mobile),
cada um com um <h1> de mesmo texto. Resultado: Screaming Frog e Googlebot
veem dois H1 na mesma página. Este PR mantém apenas um.

O que muda:
- O <h1 id="hero-heading"> do bloco desktop passa a <p>, com as mesmas
  classes visuais (render idêntico ao atual).
- O <h1 id="hero-heading-mobile"> do bloco mobile permanece como o único
  H1, alinhado a mobile-first indexing (é o H1 visível no viewport que o
  Google indexa).
- O aria-labelledby da <section> passa a apontar para hero-heading-mobile.

O que NÃO muda:
- Texto do heading (continua "Acompanhantes Premium em Portugal").
- Layout, classes de estilo e aparência, no desktop e no mobile.
- Qualquer outro bloco da home.

Resultado esperado: página com um único H1. Screaming Frog deixa de
acusar múltiplos H1.